### PR TITLE
Add Substrate OpenGov course module

### DIFF
--- a/track-1/substrate-opengov/README.md
+++ b/track-1/substrate-opengov/README.md
@@ -1,0 +1,577 @@
+# Substrate OpenGov Course
+
+This module shows how to add OpenGov-style governance to a
+Substrate-based chain. The goal is not to copy Polkadot's production
+parameters verbatim. The goal is to understand the runtime pieces that make
+OpenGov work, then assemble a local chain with public referenda, origin-specific
+tracks, conviction voting, delegation, deposits, and scheduled enactment.
+
+OpenGov is built around a simple rule: token holders vote on whether a proposal
+should be dispatched from a specific origin. The origin selects a track, and the
+track decides the deposit, timing, capacity, support curve, approval curve, and
+minimum enactment period for that class of proposal.
+
+## Learning Goals
+
+After completing this module, a learner should be able to:
+
+- Explain why OpenGov uses `pallet_referenda` and `pallet_conviction_voting`
+  instead of the older `pallet_democracy` flow.
+- Add the OpenGov pallet set to a Substrate runtime.
+- Define a small set of governance origins and tracks for a local chain.
+- Connect referenda to conviction voting so accounts can vote directly or
+  delegate by track.
+- Store proposal preimages before referenda are submitted.
+- Require both submission and decision deposits.
+- Schedule accepted proposals for enactment after the track's minimum enactment
+  period.
+- Write tests for proposal submission, voting, confirmation, enactment, and
+  unlocking.
+
+## Mental Model
+
+OpenGov is a pipeline with separate responsibilities:
+
+```text
+proposal call
+    |
+    v
+pallet_preimage
+stores the call bytes or call hash
+    |
+    v
+pallet_referenda
+tracks proposal lifecycle, deposits, origins, tracks, and enactment
+    |
+    v
+pallet_conviction_voting
+records direct votes and delegation, then reports a tally to referenda
+    |
+    v
+pallet_scheduler
+dispatches approved calls after the enactment period
+```
+
+`pallet_referenda` does not contain the vote casting logic. It runs referenda,
+tracks deposits and phases, and asks a polling implementation for the vote tally.
+`pallet_conviction_voting` is the voting side. It manages votes, vote locks,
+delegation, and turnout.
+
+The runtime is where the pieces become one governance system. The runtime
+chooses which origins exist, which calls those origins can dispatch, how many
+referenda can be deciding at the same time, and how strict each approval and
+support curve should be.
+
+## OpenGov Concepts
+
+### Origin
+
+An origin is a privilege level. A `Root` origin can dispatch highly sensitive
+calls, while a smaller origin may only be allowed to spend a limited treasury
+amount or update a parameter. Learners should treat origins as security
+boundaries.
+
+### Track
+
+A track is the voting lane for one origin. Each track has its own parameters:
+
+- decision deposit;
+- prepare period;
+- decision period;
+- confirmation period;
+- maximum number of deciding referenda;
+- minimum enactment period;
+- approval curve;
+- support curve.
+
+Small, low-risk calls can use short periods and low deposits. Runtime upgrades
+or other privileged calls need slower, stricter tracks.
+
+### Approval and Support
+
+Approval measures aye vote weight against aye plus nay vote weight after
+conviction is applied. Support measures aye votes before conviction against the
+total possible voting power. A referendum must satisfy both requirements for the
+confirmation period before it is approved.
+
+### Conviction
+
+Conviction lets a voter increase vote weight by accepting a longer lock. A vote
+with stronger conviction has more weight, but the successful voter keeps funds
+locked for longer after the referendum ends.
+
+### Delegation
+
+OpenGov supports track-level delegation. An account can delegate voting power on
+one class of referenda while keeping direct control on another class. A learner
+should test delegation and undelegation as first-class behavior, not as an
+afterthought.
+
+## Repository Starting Point
+
+Start from a recent Polkadot SDK solo-chain or parachain template. File names
+vary across SDK releases, but the work usually touches:
+
+```text
+runtime/
+  Cargo.toml
+  src/lib.rs
+  src/configs/
+  src/weights/
+node/
+  src/chain_spec.rs
+```
+
+This course assumes the runtime already has:
+
+- `frame_system`;
+- `pallet_balances`;
+- `pallet_timestamp`;
+- a block number provider;
+- a scheduler-compatible runtime call type.
+
+## Step 1: Add the Runtime Pallets
+
+Add the OpenGov-related pallets to the runtime dependency set. In recent
+templates that use the `polkadot-sdk` umbrella dependency, enable the matching
+features there. In older templates, add the crates directly. Keep every pallet in
+one SDK release family.
+
+Minimum pallet set:
+
+```text
+pallet_referenda
+pallet_conviction_voting
+pallet_preimage
+pallet_scheduler
+```
+
+Useful optional pallets:
+
+```text
+pallet_utility
+pallet_whitelist
+pallet_treasury
+```
+
+`pallet_utility` is useful because governance proposals often need batched
+calls. `pallet_whitelist` is useful when a fellowship or technical body can mark
+a proposal for a faster track. `pallet_treasury` gives learners a practical
+non-root proposal type to test.
+
+## Step 2: Decide the Local Governance Scope
+
+Do not start by copying all Polkadot origins. A learning chain can start with
+three tracks:
+
+```text
+Track 0: Root
+  Purpose: runtime upgrades and privileged changes.
+  Capacity: one deciding referendum.
+  Deposit: high for the local token.
+  Timing: long prepare, decision, and enactment periods.
+
+Track 1: Treasurer
+  Purpose: limited treasury spends.
+  Capacity: several simultaneous decisions.
+  Deposit: medium.
+  Timing: shorter than root.
+
+Track 2: Whitelisted Caller
+  Purpose: fast execution for calls approved by a trusted technical origin.
+  Capacity: many simultaneous decisions.
+  Deposit: medium or high.
+  Timing: short prepare, confirm, and enactment periods.
+```
+
+This structure gives learners meaningful contrast:
+
+- a high-risk track with strict parameters;
+- a routine spending track;
+- an emergency or pre-reviewed track.
+
+## Step 3: Define Governance Origins
+
+A runtime needs concrete origins that map to track IDs. Exact code differs by SDK
+version, but the shape is stable:
+
+```rust
+#[derive(
+    Clone,
+    Eq,
+    PartialEq,
+    Encode,
+    Decode,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
+pub enum OpenGovOrigin {
+    Root,
+    Treasurer,
+    WhitelistedCaller,
+}
+```
+
+Production runtimes normally use generated origin types and origin filters. The
+important part for this course is that every track has a deliberate dispatch
+origin. A referendum on the treasury track must not be able to dispatch the same
+calls as the root track unless the runtime intentionally permits it.
+
+## Step 4: Configure Tracks
+
+The referenda pallet asks the runtime for `TracksInfo`. Tracks describe how each
+origin should be processed. A local course can use simple constants:
+
+```rust
+pub const ROOT_TRACK: u16 = 0;
+pub const TREASURER_TRACK: u16 = 1;
+pub const WHITELIST_TRACK: u16 = 2;
+```
+
+Example track table:
+
+```text
+id  name                max deciding  decision deposit  prepare  decision
+0   root                1             1_000 units       1 hour   7 days
+1   treasurer           10            100 units         10 min   2 days
+2   whitelisted-caller  50            500 units         1 min    1 day
+```
+
+Keep numbers small in local tests. Use blocks or constants that make tests run
+quickly, then explain that production chains should set these values using real
+economic and safety analysis.
+
+The track also needs threshold curves. For a course, define:
+
+- root requires high support and high approval for most of the decision period;
+- treasurer gradually becomes easier as voters have more time to participate;
+- whitelisted caller can use lower support but still requires strong approval.
+
+The exact curve constructors move across SDK versions. If the current SDK exposes
+`pallet_referenda::Curve`, use the SDK examples for linear or reciprocal curves
+instead of hard-coding a private format.
+
+## Step 5: Configure `pallet_preimage`
+
+Governance proposals usually refer to a preimage. The preimage stores the call
+bytes separately from the referendum record. This avoids stuffing large calls
+directly into every submission and lets voters inspect exactly what will be
+dispatched.
+
+Configuration goals:
+
+- charge a deposit based on the stored bytes;
+- use the runtime's currency;
+- make preimage storage available to `pallet_referenda`;
+- test note, request, and unnote behavior.
+
+Example shape:
+
+```rust
+impl pallet_preimage::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = pallet_preimage::weights::SubstrateWeight<Runtime>;
+    type Currency = Balances;
+    type ManagerOrigin = EnsureRoot<AccountId>;
+    type BaseDeposit = PreimageBaseDeposit;
+    type ByteDeposit = PreimageByteDeposit;
+}
+```
+
+## Step 6: Configure `pallet_scheduler`
+
+Approved referenda are not dispatched immediately. The track's enactment period
+gives the network time to prepare for the change. `pallet_scheduler` performs the
+later dispatch.
+
+Configuration goals:
+
+- accept the runtime call type;
+- allow scheduling from the origin used by referenda;
+- set a realistic maximum number of scheduled calls per block;
+- ensure scheduled calls use bounded weight.
+
+Example shape:
+
+```rust
+impl pallet_scheduler::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeOrigin = RuntimeOrigin;
+    type PalletsOrigin = OriginCaller;
+    type MaximumWeight = MaximumSchedulerWeight;
+    type ScheduleOrigin = EnsureRoot<AccountId>;
+    type MaxScheduledPerBlock = ConstU32<50>;
+    type WeightInfo = pallet_scheduler::weights::SubstrateWeight<Runtime>;
+    type OriginPrivilegeCmp = EqualPrivilegeOnly;
+    type Preimages = Preimage;
+}
+```
+
+In a complete runtime, referenda must be wired to a scheduler type that can
+schedule the approved call with the proposal's dispatch origin.
+
+## Step 7: Configure `pallet_referenda`
+
+`pallet_referenda` owns the referendum lifecycle:
+
+- submitted;
+- preparing;
+- deciding;
+- confirming;
+- approved or rejected;
+- scheduled for enactment;
+- deposit refunded or slashed where applicable.
+
+Example shape:
+
+```rust
+impl pallet_referenda::Config for Runtime {
+    type RuntimeCall = RuntimeCall;
+    type RuntimeEvent = RuntimeEvent;
+    type Scheduler = Scheduler;
+    type Currency = Balances;
+    type SubmitOrigin = EnsureSigned<AccountId>;
+    type CancelOrigin = EnsureRoot<AccountId>;
+    type KillOrigin = EnsureRoot<AccountId>;
+    type Slash = Treasury;
+    type Votes = Balance;
+    type Tally = pallet_conviction_voting::Tally<Balance>;
+    type SubmissionDeposit = ReferendaSubmissionDeposit;
+    type MaxQueued = ConstU32<100>;
+    type UndecidingTimeout = UndecidingTimeout;
+    type AlarmInterval = AlarmInterval;
+    type Tracks = OpenGovTracks;
+    type Preimages = Preimage;
+    type BlockNumberProvider = System;
+    type WeightInfo = pallet_referenda::weights::SubstrateWeight<Runtime>;
+}
+```
+
+Review the SDK docs for the exact associated types in the release you use. The
+important learning outcome is that `Tracks`, `Preimages`, `Scheduler`, `Currency`,
+and `Tally` are explicit runtime decisions.
+
+## Step 8: Configure `pallet_conviction_voting`
+
+`pallet_conviction_voting` connects accounts and balances to referenda polls. It
+tracks direct votes, delegated votes, turnout, and locks.
+
+Example shape:
+
+```rust
+impl pallet_conviction_voting::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = pallet_conviction_voting::weights::SubstrateWeight<Runtime>;
+    type Currency = Balances;
+    type Polls = Referenda;
+    type MaxTurnout = TotalIssuanceOf<Balances, Runtime>;
+    type MaxVotes = ConstU32<128>;
+    type VoteLockingPeriod = VoteLockingPeriod;
+    type BlockNumberProvider = System;
+    type VotingHooks = ();
+}
+```
+
+Key invariant: vote locks must cover the consequences of a successful vote. Do
+not set the lock period shorter than the enactment period for the same class of
+proposal.
+
+## Step 9: Add Pallets to the Runtime Construct
+
+Register each pallet with a unique pallet index. Example layout:
+
+```rust
+#[frame_support::runtime]
+mod runtime {
+    #[runtime::runtime]
+    pub struct Runtime;
+
+    #[runtime::pallet_index(0)]
+    pub type System = frame_system;
+
+    #[runtime::pallet_index(10)]
+    pub type Balances = pallet_balances;
+
+    #[runtime::pallet_index(20)]
+    pub type Scheduler = pallet_scheduler;
+
+    #[runtime::pallet_index(21)]
+    pub type Preimage = pallet_preimage;
+
+    #[runtime::pallet_index(30)]
+    pub type Referenda = pallet_referenda;
+
+    #[runtime::pallet_index(31)]
+    pub type ConvictionVoting = pallet_conviction_voting;
+}
+```
+
+Never reuse a pallet index. Changing a pallet index after launch is a storage
+migration issue, so choose stable values before a public network starts.
+
+## Step 10: Add Genesis State
+
+For local tests, fund a few accounts and set balances high enough to exercise
+conviction locks:
+
+```text
+Alice: proposer and aye voter
+Bob: nay voter
+Charlie: delegate
+Dave: treasury or technical actor
+```
+
+If the course includes treasury proposals, also fund the treasury account. If it
+includes a whitelisted track, add the membership or origin rules needed to call
+the whitelist flow.
+
+## Step 11: Submit a Referendum
+
+A basic happy path is:
+
+```text
+1. Build a runtime call, such as setting a harmless storage value in a demo
+   pallet or spending a small treasury amount.
+2. Note the preimage.
+3. Submit the referendum with the intended origin.
+4. Place the decision deposit.
+5. Cast direct aye and nay votes through conviction voting.
+6. Advance blocks until the prepare period ends.
+7. Continue until approval and support satisfy the track's curves for the
+   confirmation period.
+8. Advance to the enactment block.
+9. Assert that the scheduled call executed.
+10. Remove votes and unlock balances when allowed.
+```
+
+The same flow should fail when:
+
+- the preimage hash does not match;
+- the selected origin is not allowed to dispatch the call;
+- no decision deposit is placed;
+- the track is already at capacity;
+- support or approval stays below the threshold;
+- a voter tries to transfer locked funds before unlock.
+
+## Step 12: Add Delegation
+
+Track-level delegation should be part of the course, because it is one of the
+features that makes OpenGov different from a single global voting queue.
+
+Test scenarios:
+
+- Alice delegates only the treasurer track to Charlie.
+- Alice still votes directly on the root track.
+- Charlie votes on a treasurer referendum and Alice's delegated balance counts.
+- Alice undelegates and can vote directly on later treasurer referenda.
+- Removing votes and unlocking works after the referendum lifecycle ends.
+
+## Step 13: Add a Practical Proposal Type
+
+A course is easier to understand when learners can observe a visible result.
+Good local proposal types include:
+
+- update a value in a demo configuration pallet;
+- transfer a small amount from a treasury account;
+- update a registered metadata value;
+- schedule a harmless batch call through `pallet_utility`.
+
+Avoid making the first exercise a runtime upgrade. Runtime upgrades are important
+but bring extra complexity around Wasm building, preimage size, and operational
+safety. Teach the OpenGov flow first, then add runtime upgrades as an advanced
+exercise.
+
+## Security Notes
+
+- Do not let a low-privilege origin dispatch high-privilege calls.
+- Do not make root proposals easy to pass in production.
+- Do not set a decision deposit so low that the queue can be spammed.
+- Do not allow unlimited simultaneous referenda on sensitive tracks.
+- Do not shorten vote locks below the consequences of the vote.
+- Do not ignore failed scheduled dispatches; surface the event and status.
+- Do not use local tutorial constants as production economics.
+- Do not use OpenGov pallets without benchmarking weights before a real launch.
+
+## Suggested Tests
+
+Unit tests:
+
+- track lookup returns the expected track for each origin;
+- invalid origin-to-track mapping fails;
+- preimage deposit is reserved and released correctly;
+- decision deposit is required before deciding;
+- aye and nay conviction weights affect approval;
+- support is based on turnout before conviction;
+- delegation is isolated by track;
+- locked funds cannot be transferred;
+- approved calls are scheduled after the enactment period;
+- rejected calls are not scheduled;
+- cancel refunds deposits;
+- kill slashes deposits according to the configured handler.
+
+End-to-end local node checks:
+
+- start the chain;
+- submit a preimage through the UI or script;
+- submit a referendum on the treasurer track;
+- vote with two accounts using different conviction levels;
+- observe status moving from preparing to deciding to confirming;
+- wait for enactment;
+- verify the target state changed;
+- remove votes and unlock balances.
+
+## Common Mistakes
+
+### Using `pallet_democracy`
+
+OpenGov referenda should use `pallet_referenda` with
+`pallet_conviction_voting`. The older democracy pallet is not the OpenGov voting
+path.
+
+### Treating Tracks as Labels Only
+
+Tracks are security and economics configuration. They control timing, deposits,
+capacity, and thresholds. A track choice should be reviewed like a permission.
+
+### Skipping Preimages
+
+If voters cannot inspect the exact call, they cannot responsibly vote. Store and
+reference preimages for real proposals.
+
+### Forgetting the Scheduler
+
+An approved referendum normally schedules a call for later enactment. If nothing
+dispatches the call after approval, the governance pipeline is incomplete.
+
+### Copying Production Parameters Blindly
+
+Polkadot parameters are tuned for Polkadot's risk model and economics. A new
+chain should start from its own token supply, security assumptions, block time,
+and governance expectations.
+
+## Learner Deliverables
+
+At the end of the module, the learner should submit:
+
+- a short design note listing origins, tracks, deposits, periods, and thresholds;
+- runtime configuration for `Preimage`, `Scheduler`, `Referenda`, and
+  `ConvictionVoting`;
+- at least one visible proposal type;
+- unit tests for voting, deposits, delegation, and enactment;
+- a local runbook showing how to submit and vote on a referendum;
+- screenshots or logs proving that an approved proposal executed.
+
+## References
+
+- Polkadot OpenGov overview:
+  <https://wiki.polkadot.com/learn/learn-polkadot-opengov/>
+- Polkadot OpenGov origins and tracks:
+  <https://wiki.polkadot.com/learn/learn-polkadot-opengov-origins/>
+- `pallet_referenda` Rust docs:
+  <https://paritytech.github.io/polkadot-sdk/master/pallet_referenda/>
+- `pallet_conviction_voting` Rust docs:
+  <https://paritytech.github.io/polkadot-sdk/master/pallet_conviction_voting/>
+- Add an existing pallet to a runtime:
+  <https://docs.polkadot.com/parachains/customize-runtime/add-existing-pallets/>

--- a/track-1/substrate-opengov/implementation-checklist.md
+++ b/track-1/substrate-opengov/implementation-checklist.md
@@ -1,0 +1,128 @@
+# Implementation Checklist
+
+Use this checklist while building the OpenGov course chain. It is intentionally
+ordered from runtime design to local verification.
+
+## Design
+
+- [ ] Write the purpose of the chain's OpenGov module.
+- [ ] Choose the proposal types that learners will test.
+- [ ] Define the account roles used in tests.
+- [ ] Choose a block time assumption for converting minutes or days to blocks.
+- [ ] Define at least three tracks: root, treasurer, and whitelisted caller.
+- [ ] Document each track's origin, capacity, deposit, periods, and threshold
+      curves.
+- [ ] Mark which calls each origin is allowed to dispatch.
+- [ ] Explain why low-risk and high-risk calls use different tracks.
+
+## Dependencies
+
+- [ ] Add `pallet_referenda`.
+- [ ] Add `pallet_conviction_voting`.
+- [ ] Add `pallet_preimage`.
+- [ ] Add `pallet_scheduler`.
+- [ ] Add `pallet_utility` if batch calls are part of the tutorial.
+- [ ] Add `pallet_whitelist` if the whitelisted caller track is implemented.
+- [ ] Keep every dependency in the same Polkadot SDK release family.
+- [ ] Confirm that `std` features are enabled for native tests.
+
+## Origins and Tracks
+
+- [ ] Define the runtime origin type or generated origins used by OpenGov.
+- [ ] Assign a stable track ID to every origin.
+- [ ] Implement or configure `TracksInfo`.
+- [ ] Set low local-test periods so tests finish quickly.
+- [ ] Add comments warning that tutorial economics are not production settings.
+- [ ] Test every origin-to-track mapping.
+- [ ] Test that a wrong origin cannot use a privileged track.
+
+## Preimage
+
+- [ ] Configure preimage deposits.
+- [ ] Wire `pallet_preimage` into `pallet_referenda`.
+- [ ] Test noting a preimage.
+- [ ] Test submitting a referendum that references the preimage.
+- [ ] Test failure when the preimage hash is missing or wrong.
+- [ ] Test deposit release or cleanup after the lifecycle ends.
+
+## Scheduler
+
+- [ ] Configure the scheduler with the runtime call type.
+- [ ] Set maximum scheduled calls per block.
+- [ ] Set bounded scheduler weight.
+- [ ] Connect referenda to the scheduler.
+- [ ] Test that an approved referendum schedules the call.
+- [ ] Test that the call executes after the enactment period.
+- [ ] Test that rejected referenda do not schedule calls.
+
+## Referenda
+
+- [ ] Configure `RuntimeCall`.
+- [ ] Configure `RuntimeEvent`.
+- [ ] Configure `Scheduler`.
+- [ ] Configure `Currency`.
+- [ ] Configure `SubmitOrigin`.
+- [ ] Configure `CancelOrigin`.
+- [ ] Configure `KillOrigin`.
+- [ ] Configure `Slash`.
+- [ ] Configure `Votes`.
+- [ ] Configure `Tally`.
+- [ ] Configure `SubmissionDeposit`.
+- [ ] Configure `MaxQueued`.
+- [ ] Configure `UndecidingTimeout`.
+- [ ] Configure `AlarmInterval`.
+- [ ] Configure `Tracks`.
+- [ ] Configure `Preimages`.
+- [ ] Configure `BlockNumberProvider`.
+- [ ] Add the pallet to the runtime construct with a unique pallet index.
+
+## Conviction Voting
+
+- [ ] Configure `Currency`.
+- [ ] Configure `Polls = Referenda`.
+- [ ] Configure `MaxTurnout`.
+- [ ] Configure `MaxVotes`.
+- [ ] Configure `VoteLockingPeriod`.
+- [ ] Configure `BlockNumberProvider`.
+- [ ] Configure `VotingHooks`.
+- [ ] Add the pallet to the runtime construct with a unique pallet index.
+- [ ] Test direct aye votes.
+- [ ] Test direct nay votes.
+- [ ] Test vote removal.
+- [ ] Test balance locks.
+- [ ] Test track-level delegation.
+- [ ] Test undelegation.
+
+## Runtime Construct
+
+- [ ] Register `System`.
+- [ ] Register `Balances`.
+- [ ] Register `Scheduler`.
+- [ ] Register `Preimage`.
+- [ ] Register `Referenda`.
+- [ ] Register `ConvictionVoting`.
+- [ ] Register optional `Utility`, `Whitelist`, or `Treasury` pallets.
+- [ ] Confirm every pallet index is unique.
+- [ ] Avoid changing pallet indices after any public launch.
+
+## Genesis and Local Node
+
+- [ ] Fund proposer accounts.
+- [ ] Fund voter accounts.
+- [ ] Fund delegate accounts.
+- [ ] Fund the treasury account if treasury proposals are tested.
+- [ ] Add any required technical or whitelist actors.
+- [ ] Build the node.
+- [ ] Start a local chain.
+- [ ] Submit one full referendum through CLI, UI, or script.
+- [ ] Record the events that prove each lifecycle stage occurred.
+
+## Validation
+
+- [ ] Run `cargo fmt`.
+- [ ] Run `cargo check` or `cargo build`.
+- [ ] Run unit tests.
+- [ ] Run any runtime benchmark or weight check required by the template.
+- [ ] Run a local node smoke test.
+- [ ] Capture logs showing preimage submission, referendum submission, voting,
+      approval, scheduling, dispatch, and unlock.

--- a/track-1/substrate-opengov/review-checklist.md
+++ b/track-1/substrate-opengov/review-checklist.md
@@ -1,0 +1,79 @@
+# Review Checklist
+
+Use this checklist to review a learner's OpenGov implementation before accepting
+the module.
+
+## Conceptual Accuracy
+
+- [ ] The submission explains OpenGov as public referenda plus origin-specific
+      tracks.
+- [ ] It distinguishes `pallet_referenda` from `pallet_conviction_voting`.
+- [ ] It does not present `pallet_democracy` as the OpenGov path.
+- [ ] It explains approval and support separately.
+- [ ] It explains conviction locks and their consequences.
+- [ ] It explains track-level delegation.
+- [ ] It explains why preimages are needed.
+- [ ] It explains why approved referenda are scheduled for later enactment.
+
+## Runtime Safety
+
+- [ ] High-privilege calls are only available through high-privilege origins.
+- [ ] Low-risk tracks cannot dispatch root-level calls.
+- [ ] Track capacity is limited.
+- [ ] Decision deposits are not trivially cheap.
+- [ ] Root-like tracks have stricter thresholds than routine tracks.
+- [ ] Vote locks are not shorter than the relevant enactment period.
+- [ ] Scheduler weight limits are configured.
+- [ ] Pallet indices are unique.
+- [ ] The implementation does not copy production network parameters without
+      explaining why they fit the new chain.
+
+## Functional Coverage
+
+- [ ] A learner can submit a preimage.
+- [ ] A learner can submit a referendum on the intended track.
+- [ ] A learner can place the decision deposit.
+- [ ] A learner can vote aye with conviction.
+- [ ] A learner can vote nay with conviction.
+- [ ] A learner can delegate by track.
+- [ ] A learner can undelegate.
+- [ ] An approved referendum schedules a call.
+- [ ] A scheduled call executes after the enactment period.
+- [ ] A rejected referendum does not execute.
+- [ ] A voter can remove votes and unlock when allowed.
+
+## Tests
+
+- [ ] Tests cover valid origin-to-track mapping.
+- [ ] Tests cover invalid origin-to-track mapping.
+- [ ] Tests cover preimage submission.
+- [ ] Tests cover missing preimage failure.
+- [ ] Tests cover decision deposit requirement.
+- [ ] Tests cover support and approval behavior.
+- [ ] Tests cover conviction-weighted voting.
+- [ ] Tests cover delegation isolation by track.
+- [ ] Tests cover lock enforcement.
+- [ ] Tests cover scheduled enactment.
+- [ ] Tests cover rejection.
+- [ ] Tests cover cancel or kill behavior if those origins are exposed.
+
+## Documentation Quality
+
+- [ ] The course can be followed from a clean template.
+- [ ] The proposal flow is written step by step.
+- [ ] Code snippets are clearly marked as release-dependent shapes when they are
+      not exact drop-in code.
+- [ ] The document links to official Polkadot or Polkadot SDK references.
+- [ ] The document names common mistakes and how to avoid them.
+- [ ] The document includes learner deliverables.
+- [ ] The final runbook produces visible local evidence.
+
+## Acceptance Criteria
+
+- [ ] The runtime compiles.
+- [ ] The tests pass.
+- [ ] A local node can run.
+- [ ] At least one referendum is submitted, voted on, approved, enacted, and
+      verified.
+- [ ] The submitted documentation is accurate enough that a learner can reproduce
+      the same flow.


### PR DESCRIPTION
Submission for #9 (200 USD OpenGuild bounty).

## What changed

- Adds a Track 1 Substrate OpenGov course module under `track-1/substrate-opengov/`.
- Explains the OpenGov pipeline: preimage storage, referenda lifecycle, conviction voting, track-level delegation, and scheduled enactment.
- Documents a local runtime design with root, treasurer, and whitelisted caller tracks.
- Includes implementation and review checklists covering pallet wiring, origin-to-track mapping, deposits, voting, delegation, scheduler enactment, and safety review.
- Calls out common mistakes such as using `pallet_democracy`, treating tracks as labels only, skipping preimages, or copying production parameters blindly.

## Duplicate / attempt check

Immediately before opening this PR I checked issue #9 and this repository:

- issue #9 was open, had zero comments, and had no assignee.
- this repository had no open or closed PR matching OpenGov or the issue title.

## Validation

- `git diff --cached --check` before commit
- `git diff --check -- track-1/substrate-opengov`
- `LC_ALL=C rg -n "[^\\x00-\\x7F]" track-1/substrate-opengov || true`
- `npx --yes markdownlint-cli@0.43.0 track-1/substrate-opengov/*.md`
- Reference link HTTP status check: all listed links returned 200.

## Payout info

- Payout details can be provided from `william08190` on acceptance.
