### PR TITLE
Add nominated proof-of-stake course module

### DIFF
--- a/track-1/nominated-proof-of-stake-blockchain/README.md
+++ b/track-1/nominated-proof-of-stake-blockchain/README.md
@@ -1,0 +1,327 @@
+# Nominated Proof-of-Stake Substrate Blockchain Course
+
+This course module explains how to design a local Substrate-based blockchain
+that uses Nominated Proof of Stake, or NPoS, for validator selection and stake
+weighted security. It is written for learners who already know the basic shape
+of a Polkadot SDK runtime and now need to understand how staking, sessions,
+validator elections, rewards, and slashing fit together.
+
+The module is intentionally implementation-oriented. It does not claim that a
+toy chain has the same economics as Polkadot, but it shows which runtime pieces
+must exist before a learner can build a credible NPoS demonstration chain.
+
+## Learning Goals
+
+After finishing this module, a learner should be able to:
+
+- Explain the difference between plain Proof of Stake and NPoS.
+- Describe the roles of validator candidate, nominator, inactive staker, and
+  session authority.
+- Add the staking-related FRAME pallets that a solo chain needs.
+- Configure sessions and eras so validator elections happen predictably.
+- Seed initial authorities, validators, nominators, balances, and staking
+  intentions in genesis.
+- Run the staking lifecycle from `bond` to `validate`, `nominate`, `chill`,
+  payout, and unbond.
+- Explain why election limits, exposure pages, commission, rewards, and
+  slashing are part of the security model.
+- Write tests and manual checks that prove only elected validators produce
+  blocks for the next era.
+
+## Mental Model
+
+NPoS lets token holders back validator candidates without running validator
+infrastructure themselves. Validators produce blocks and participate in
+finality. Nominators choose trustworthy validator candidates and place stake
+behind them. The staking election chooses an active validator set from those
+signals.
+
+```text
+validator candidate       nominator
+        |                    |
+        | validate()         | nominate([validators])
+        +----------+---------+
+                   |
+                   v
+            staking election
+                   |
+                   v
+       active validator set for next era
+                   |
+                   v
+       sessions, rewards, offences, slashing
+```
+
+The key idea is that the validator set is not a static admin list. It is a
+runtime result that changes when stake, nominations, chilling, slashing, and
+election constraints change.
+
+## Runtime Shape
+
+A practical NPoS solo-chain runtime normally combines these responsibilities:
+
+- `pallet_balances` holds the staking asset.
+- `pallet_staking` tracks bonded stake, roles, eras, rewards, and slashes.
+- `pallet_session` rotates session keys and applies the elected authority set.
+- A block production pallet such as BABE or Aura creates blocks.
+- A finality pallet such as GRANDPA finalizes blocks.
+- `pallet_authorship` attributes produced blocks to validators for rewards.
+- `pallet_offences` records validator misbehavior and routes reports.
+- An election provider selects active validators from candidates and nominators.
+- A voter list, such as bags list or a bounded map approach, keeps elections
+  within runtime weight limits.
+
+The exact crate names and version pins should match the Polkadot SDK release
+used by the template. The design is stable even when the dependency paths move.
+
+## Minimal Implementation Path
+
+Start from a solo-chain template rather than a parachain template. A parachain
+uses collators and relay-chain security, while this course is about a chain
+whose own staking system chooses validator authorities.
+
+### 1. Add Staking Dependencies
+
+Add runtime dependencies for staking, session management, authorship, offences,
+and the election provider. Keep the versions aligned with the rest of the SDK:
+
+```toml
+pallet-staking = { workspace = true }
+pallet-session = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-offences = { workspace = true }
+pallet-election-provider-multi-phase = { workspace = true }
+```
+
+If the template uses explicit versions instead of workspace dependencies, use
+the same Polkadot SDK release for every pallet. Mixing SDK releases is one of
+the fastest ways to get trait and type errors.
+
+### 2. Define Staking Types
+
+Choose small constants for a local course chain. They must be realistic enough
+to show the mechanics, but short enough that a learner can watch era changes
+without waiting for hours:
+
+```rust
+pub const SessionsPerEra: sp_staking::SessionIndex = 3;
+pub const BondingDuration: sp_staking::EraIndex = 2;
+pub const MaxNominations: u32 = 16;
+pub const MaxValidators: u32 = 32;
+```
+
+For a production chain, these values should be changed only after economic
+analysis, benchmarking, and governance review. For a course chain, the point is
+to make validator rotation and payouts visible in a short demo.
+
+### 3. Configure `pallet_staking`
+
+The staking config ties together balances, session rotation, reward payout,
+slash handling, election output, and administrative origins. The important
+review question is not "does it compile?" but "who can change each security
+parameter, and what happens when a validator misbehaves?"
+
+At minimum, review these areas:
+
+- The currency used for bonded stake.
+- The era payout implementation.
+- The slash destination and slash cancellation origin.
+- The session manager connection.
+- The maximum validator count and nominator limits.
+- The election provider and voter list strategy.
+- The reward destination behavior.
+- The weight info generated by benchmarks or a template fallback.
+
+### 4. Connect Sessions and Keys
+
+Staking chooses validator accounts, but the consensus engine needs session
+keys. The runtime must map the elected validator account to the session keys
+used by block production and finality.
+
+For a BABE plus GRANDPA style demo, the chain spec should give each initial
+authority:
+
+- a stash account with bonded stake;
+- a validator role declaration;
+- session keys for block production;
+- GRANDPA authority keys;
+- enough free balance for fees and existential deposits.
+
+The lesson should show that a candidate is not active immediately. A learner
+should validate, wait for the election boundary, and then observe the account
+joining the active validator set.
+
+### 5. Seed Genesis Stakers
+
+The genesis configuration should include at least:
+
+- two or more initial validator candidates;
+- one or more nominators with nominations spread across candidates;
+- a validator count smaller than the candidate count;
+- balances high enough to cover the bonded amount;
+- session keys for the initial active authorities.
+
+This setup makes the election visible. If every candidate is always selected,
+the learner cannot observe the effect of nominations or validator limits.
+
+Example scenario:
+
+```text
+validator count: 2
+candidate A: own stake 1000
+candidate B: own stake 1000
+candidate C: own stake 1000
+nominator 1: nominates A and C with 500
+nominator 2: nominates B and C with 800
+```
+
+At the next era, the election provider should select an active set based on the
+configured election logic and constraints.
+
+## Learner Walkthrough
+
+### Bond Funds
+
+Bonding locks tokens so they can be used for staking. The bonded account is the
+economic identity. Modern staking flows increasingly move away from separate
+controller accounts, so the course should call out which model the chosen SDK
+template exposes.
+
+Checks:
+
+- The account balance decreases or becomes locked according to the pallet.
+- The account appears in staking storage as a bonded staker.
+- The bonded amount cannot be transferred freely.
+
+### Become a Validator Candidate
+
+Call `validate` from a bonded account. This declares intent to be a validator,
+but it does not instantly place the account in the active validator set.
+
+Checks:
+
+- The account has validator preferences, including commission.
+- The account is eligible for the next election.
+- Session keys are registered before the account can safely validate.
+
+### Nominate Validators
+
+Call `nominate` from a bonded account and choose validator candidates. The
+nominator shares rewards and slash risk with the chosen validators.
+
+Checks:
+
+- Nominations are bounded by `MaxNominations`.
+- Invalid or duplicate targets are rejected.
+- The nominator is exposed to slash risk for elected validators it backs.
+
+### Advance Sessions and Eras
+
+Produce blocks until the chain crosses the configured session and era
+boundaries. The active validator set should only change at the correct
+boundary, not in the middle of a session.
+
+Checks:
+
+- Session index increments on schedule.
+- Era index increments after the configured number of sessions.
+- The new validator set appears after the election is applied.
+
+### Pay Rewards
+
+After an era has ended, call `payout_stakers` for a validator and era. Rewards
+are split according to validator points, commission, and exposure.
+
+Checks:
+
+- Reward destinations match the selected payee.
+- Validator commission is taken before the remainder is shared.
+- Large nominator sets are handled through exposure pages when configured.
+
+### Chill and Unbond
+
+Call `chill` to stop seeking validator or nominator status. Then call `unbond`
+and wait through the bonding duration before withdrawal.
+
+Checks:
+
+- A chilled validator is not elected in the next era.
+- Unbonded funds remain locked until the bonding duration passes.
+- `withdraw_unbonded` releases eligible unlocking chunks only.
+
+## Tests to Include
+
+A useful course implementation should include unit or integration tests for:
+
+- initial genesis validators and nominators;
+- candidate declaration through `validate`;
+- nomination limits and invalid nomination targets;
+- era transition and validator set update;
+- reward payout to validator and nominators;
+- chilling before the next election;
+- unbonding and withdrawal after the bonding duration;
+- slash reporting or a mocked offence path;
+- non-staker accounts failing staking-only flows;
+- session keys required before a validator is usable.
+
+Tests should avoid asserting exact production economics unless the runtime uses
+the same constants and payout curve as a live network. Instead, they should
+prove the state transitions that the course teaches.
+
+## Common Failure Modes
+
+- Treating validator candidates as active validators immediately.
+- Forgetting session keys in the chain spec.
+- Giving every candidate a validator slot, which hides the election.
+- Setting session or era lengths so long that the demo cannot be observed.
+- Using balances that are too small for bonds, fees, or deposits.
+- Ignoring validator commission in payout expectations.
+- Forgetting that nominators share slash risk with validators they back.
+- Copying Polkadot production constants into a tiny local test chain.
+- Adding staking without benchmarking weights before production use.
+
+## Security Notes
+
+NPoS is an economic security mechanism, not only a runtime wiring exercise.
+Before a chain uses this in production, the team should review:
+
+- how many validators are required for liveness and decentralization;
+- whether the staking token has enough distribution to support security;
+- how slash reports are generated, verified, and appealed;
+- whether validator commission creates centralization incentives;
+- how emergency origins can pause staking or force eras;
+- how runtime upgrades are governed;
+- whether off-chain election work is reliable and reproducible;
+- how telemetry and monitoring detect offline validators.
+
+For the course, those questions should be visible even if the implementation
+uses shortened eras and mocked offence paths.
+
+## Suggested Directory Layout
+
+```text
+track-1/nominated-proof-of-stake-blockchain/
+  README.md
+  implementation-checklist.md
+  review-checklist.md
+```
+
+The README is the learner guide. The implementation checklist is for builders.
+The review checklist is for maintainers who need to verify that the submission
+actually teaches a working NPoS runtime design.
+
+## References
+
+- [Polkadot staking guide][staking-guide]
+- [Polkadot proof-of-stake consensus][pos-consensus]
+- [FRAME staking pallet docs][staking-pallet]
+- [Add an existing pallet to a runtime][add-pallet]
+
+[staking-guide]:
+  https://wiki.polkadot.com/learn/learn-staking/
+[pos-consensus]:
+  https://docs.polkadot.com/reference/polkadot-hub/consensus-and-security/pos-consensus/
+[staking-pallet]:
+  https://docs.rs/pallet-staking/latest/pallet_staking/
+[add-pallet]:
+  https://docs.polkadot.com/parachains/customize-runtime/add-existing-pallets/

--- a/track-1/nominated-proof-of-stake-blockchain/README.md
+++ b/track-1/nominated-proof-of-stake-blockchain/README.md
@@ -310,6 +310,25 @@ The README is the learner guide. The implementation checklist is for builders.
 The review checklist is for maintainers who need to verify that the submission
 actually teaches a working NPoS runtime design.
 
+## Maintainer Acceptance Evidence
+
+A complete learner submission should provide evidence that the runtime behavior
+matches the lesson. The companion `demo-runbook.md` file lists the checks that
+should be captured before marking the lesson complete:
+
+- the initial validator and nominator accounts in genesis;
+- the active validator set before and after an era change;
+- the staking ledger for a validator and a nominator;
+- the session key registration path;
+- a successful `validate` call;
+- a successful `nominate` call;
+- a payout call after the era closes;
+- a chill and unbond flow;
+- at least one rejected staking action from an invalid account.
+
+This makes the bounty easier to review because the maintainer can compare the
+course text against observable chain state.
+
 ## References
 
 - [Polkadot staking guide][staking-guide]

--- a/track-1/nominated-proof-of-stake-blockchain/demo-runbook.md
+++ b/track-1/nominated-proof-of-stake-blockchain/demo-runbook.md
@@ -1,0 +1,208 @@
+# Local Demo Runbook
+
+This runbook turns the NPoS course into a concrete review exercise. It is not a
+replacement for production benchmarking or security review. It is a small local
+demo that proves the course teaches observable staking behavior.
+
+## Demo Goal
+
+By the end of the demo, a reviewer should see:
+
+- bonded accounts with staking ledgers;
+- validator candidates that are not active immediately;
+- nominators backing validator candidates;
+- an era boundary that applies a new active validator set;
+- rewards that can be paid after an era ends;
+- chilled or unbonding stakers leaving the election path;
+- a rejected call that proves the runtime enforces staking rules.
+
+## Suggested Local Accounts
+
+Use deterministic development accounts so learners can repeat the same demo:
+
+- Alice as an initial validator;
+- Bob as an initial validator;
+- Charlie as a validator candidate;
+- Dave as a nominator;
+- Eve as a nominator;
+- Ferdie as a negative-test account with insufficient stake.
+
+The chain spec should fund every account except the negative-test case with
+enough free balance for fees, staking locks, and existential deposits.
+
+## Suggested Runtime Constants
+
+For a course chain, keep the cycle short:
+
+```text
+validator count: 2
+candidate count: 3
+sessions per era: 3
+bonding duration: 2 eras
+maximum nominations: 16
+minimum validator bond: small but non-zero
+minimum nominator bond: small but non-zero
+```
+
+These numbers are intentionally small. They make the lesson reviewable on a
+laptop while preserving the important NPoS state transitions.
+
+## Step 1: Start the Chain
+
+Start two validator nodes with the development chain spec. The exact command
+depends on the template, but the reviewer should record:
+
+- the chain spec file used;
+- the binary or node command used;
+- the initial authority accounts;
+- the first finalized block;
+- the initial session index;
+- the initial era index.
+
+Acceptance evidence:
+
+```text
+session.currentIndex == 0 or 1
+staking.activeEra exists
+session.validators contains Alice and Bob
+Charlie is not an active validator yet
+```
+
+## Step 2: Inspect Genesis Staking State
+
+Query staking storage for each seeded account.
+
+The reviewer should confirm:
+
+- Alice and Bob are bonded;
+- Alice and Bob have validator preferences;
+- Dave and Eve are bonded as nominators if seeded that way;
+- Charlie has funds and session keys but is not yet active;
+- the validator count is lower than the candidate count.
+
+This proves the course setup can demonstrate an actual election rather than a
+static validator list.
+
+## Step 3: Register Session Keys
+
+Before Charlie can safely validate, register session keys for Charlie. If the
+template exposes a command to rotate keys, record the generated key material
+only locally. Do not publish private keys in course material or PR comments.
+
+Acceptance evidence:
+
+```text
+session.nextKeys(Charlie) is set
+Charlie is still not active until the election boundary
+```
+
+## Step 4: Bond and Validate
+
+From Charlie, bond funds and declare validator intent.
+
+Expected observations:
+
+- Charlie has a staking ledger;
+- Charlie has validator preferences;
+- Charlie remains outside the active validator set until the era changes;
+- a candidate with missing session keys is rejected or documented as unsafe.
+
+Negative check:
+
+```text
+Ferdie validate() with insufficient bond fails
+```
+
+## Step 5: Nominate Candidates
+
+From Dave and Eve, nominate overlapping validator candidates.
+
+Example nominations:
+
+```text
+Dave nominates Alice and Charlie
+Eve nominates Bob and Charlie
+```
+
+Expected observations:
+
+- nominations are stored for Dave and Eve;
+- duplicate targets are rejected;
+- more than `MaxNominations` targets are rejected;
+- nominators are exposed to reward and slash risk for elected targets.
+
+## Step 6: Advance Sessions and Eras
+
+Produce blocks until the next era is applied.
+
+Record:
+
+- the session index before the era change;
+- the active era before the change;
+- the active validator set before the change;
+- the same values after the change.
+
+Expected observations:
+
+```text
+session index increments first
+era index increments after SessionsPerEra sessions
+validator set changes only at the boundary
+```
+
+If Charlie has enough backing and the election selects Charlie, Charlie should
+appear in the active validator set for the next era.
+
+## Step 7: Pay Out Rewards
+
+After an era is complete, call `payout_stakers` for one validator and the
+completed era.
+
+Expected observations:
+
+- payout succeeds only for a completed era;
+- validator commission is applied before nominator reward sharing;
+- the selected reward destination receives funds or stake;
+- repeated payout for the same validator and era is rejected or has no effect.
+
+Record balances before and after the payout so the learner can see the change.
+
+## Step 8: Chill and Unbond
+
+Call `chill` for Charlie or one nominator. Then unbond part of the stake and
+advance eras until withdrawal is allowed.
+
+Expected observations:
+
+- chilled stakers stop participating in later elections;
+- unbonded chunks stay locked through the bonding duration;
+- `withdraw_unbonded` releases only eligible chunks;
+- the account keeps enough free balance for fees.
+
+## Step 9: Review Failure Modes
+
+The demo should include at least one failing path for each category:
+
+- insufficient bond;
+- too many nomination targets;
+- nomination target is not a validator candidate;
+- payout for an era that has not ended;
+- unbond withdrawal before the bonding duration has passed;
+- validator intent without session-key readiness.
+
+These failures are important because they prove the course covers runtime
+constraints, not only successful calls.
+
+## Evidence Package
+
+For a final course submission, include screenshots, logs, or test output showing:
+
+- genesis validator and nominator setup;
+- pre-election validator set;
+- post-election validator set;
+- payout result;
+- unbonding and withdrawal timeline;
+- at least three negative tests.
+
+Do not include private keys, seed phrases, payment identifiers, or personal
+account details in the evidence.

--- a/track-1/nominated-proof-of-stake-blockchain/implementation-checklist.md
+++ b/track-1/nominated-proof-of-stake-blockchain/implementation-checklist.md
@@ -1,0 +1,86 @@
+# Implementation Checklist
+
+Use this checklist to build the course module for a local NPoS chain. Each item
+should be either implemented, documented as intentionally simplified, or left
+with a clear learner exercise.
+
+## Repository Structure
+
+- Add the module under `track-1/nominated-proof-of-stake-blockchain/`.
+- Keep the learner guide in `README.md`.
+- Keep builder checks in `implementation-checklist.md`.
+- Keep maintainer checks in `review-checklist.md`.
+- Use short Markdown lines so the content is easy to review in diffs.
+
+## Runtime Pallets
+
+- Include `pallet_balances` for the staking asset.
+- Include `pallet_staking` for bonded stake and NPoS state.
+- Include `pallet_session` for validator set rotation.
+- Include a block production pallet suitable for a solo chain.
+- Include a finality pallet suitable for a solo chain.
+- Include `pallet_authorship` for validator reward points.
+- Include `pallet_offences` or a documented mocked offence path.
+- Include an election provider for validator selection.
+- Include a bounded voter list strategy for election weight safety.
+
+## Runtime Configuration
+
+- Define local demo constants for sessions per era.
+- Define a short bonding duration for learner visibility.
+- Bound the number of validators.
+- Bound the number of nominations per nominator.
+- Configure reward payout behavior.
+- Configure slash destination and slash cancellation authority.
+- Configure validator commission behavior.
+- Configure session key conversion.
+- Connect staking as the session manager.
+- Use generated weights or explicitly call out template weights.
+
+## Genesis Configuration
+
+- Seed enough balances for all validator and nominator accounts.
+- Seed at least three validator candidates.
+- Set the validator count lower than the candidate count.
+- Seed at least two nominators with overlapping nominations.
+- Register session keys for initial validator authorities.
+- Set reward destinations for demo accounts.
+- Document which accounts are learners, validators, and nominators.
+
+## Learner Flow
+
+- Show how to bond funds.
+- Show how to declare validator intent with `validate`.
+- Show how to nominate validator candidates with `nominate`.
+- Show how to inspect staking ledger and nomination state.
+- Show how to advance sessions and eras.
+- Show how to inspect the active validator set.
+- Show how to call `payout_stakers`.
+- Show how validator commission affects rewards.
+- Show how to chill a staker.
+- Show how to unbond and withdraw after the bonding duration.
+
+## Tests
+
+- Test genesis staking state.
+- Test validator candidate registration.
+- Test nomination limits.
+- Test invalid nomination rejection.
+- Test era transition.
+- Test active validator set change.
+- Test reward payout effects.
+- Test chilling before a later era.
+- Test unbonding and withdrawal timing.
+- Test non-staker rejection paths.
+- Test missing session key failure or safety handling.
+- Test offence or slash routing when included.
+
+## Documentation Quality
+
+- Explain the difference between validator candidates and active validators.
+- Explain that nominators share both rewards and slash risk.
+- Explain why election limits matter for runtime weight.
+- Explain why production constants should not be copied from a toy chain.
+- Explain the role of sessions and eras separately.
+- Explain where production benchmarking is required.
+- Link to official Polkadot and FRAME references.

--- a/track-1/nominated-proof-of-stake-blockchain/implementation-checklist.md
+++ b/track-1/nominated-proof-of-stake-blockchain/implementation-checklist.md
@@ -10,6 +10,7 @@ with a clear learner exercise.
 - Keep the learner guide in `README.md`.
 - Keep builder checks in `implementation-checklist.md`.
 - Keep maintainer checks in `review-checklist.md`.
+- Keep local verification steps in `demo-runbook.md`.
 - Use short Markdown lines so the content is easy to review in diffs.
 
 ## Runtime Pallets
@@ -84,3 +85,14 @@ with a clear learner exercise.
 - Explain the role of sessions and eras separately.
 - Explain where production benchmarking is required.
 - Link to official Polkadot and FRAME references.
+
+## Acceptance Evidence
+
+- Provide the local chain spec or document the template used.
+- Record the initial validator set.
+- Record the validator set after an era transition.
+- Record at least one nominator backing an elected validator.
+- Record one successful payout call.
+- Record one chill and unbond flow.
+- Record at least three rejected calls for invalid staking actions.
+- Do not publish private keys, seed phrases, or payout identifiers.

--- a/track-1/nominated-proof-of-stake-blockchain/review-checklist.md
+++ b/track-1/nominated-proof-of-stake-blockchain/review-checklist.md
@@ -32,6 +32,7 @@ Use this checklist when reviewing the NPoS course submission for issue #5.
 - The test list covers state transitions, not only happy path calls.
 - The failure modes help learners debug realistic staking mistakes.
 - The security notes call out production risks and review areas.
+- The demo runbook gives reviewers concrete state checks to request.
 
 ## Maintainability
 
@@ -40,3 +41,4 @@ Use this checklist when reviewing the NPoS course submission for issue #5.
 - Links are current and official.
 - No public payout details are embedded in the course material.
 - The submission can be reviewed without running a custom external service.
+- The evidence package avoids private keys, seed phrases, and payment details.

--- a/track-1/nominated-proof-of-stake-blockchain/review-checklist.md
+++ b/track-1/nominated-proof-of-stake-blockchain/review-checklist.md
@@ -1,0 +1,42 @@
+# Review Checklist
+
+Use this checklist when reviewing the NPoS course submission for issue #5.
+
+## Bounty Fit
+
+- The module is about a Substrate chain with Nominated Proof of Stake.
+- The guide describes validators, nominators, sessions, eras, rewards, and
+  slashing.
+- The guide is implementation-oriented, not only a high level article.
+- The content references official Polkadot or FRAME material.
+- The content does not claim toy-chain economics are production-ready.
+
+## Technical Correctness
+
+- Validator candidates are not treated as active validators immediately.
+- Staking is connected to session rotation.
+- Session keys are required for active validators.
+- The validator count can be smaller than the candidate count.
+- Nominators have bounded nomination targets.
+- Reward payout includes validator commission.
+- Slash risk is shared by validators and exposed nominators.
+- Era and session boundaries are described separately.
+- Election limits and runtime weight concerns are discussed.
+- Unbonding waits for a bonding duration before withdrawal.
+
+## Demo Completeness
+
+- The suggested genesis has multiple validators and nominators.
+- The walkthrough covers bonding, validating, nominating, era advancement,
+  payout, chilling, and unbonding.
+- The test list covers state transitions, not only happy path calls.
+- The failure modes help learners debug realistic staking mistakes.
+- The security notes call out production risks and review areas.
+
+## Maintainability
+
+- File names and paths follow the Track 1 course convention.
+- Markdown is readable in GitHub diffs.
+- Links are current and official.
+- No public payout details are embedded in the course material.
+- The submission can be reviewed without running a custom external service.


### PR DESCRIPTION
Submission for #5 (250 USD OpenGuild bounty).

## What changed

- Adds a Track 1 Nominated Proof-of-Stake Substrate course module under `track-1/nominated-proof-of-stake-blockchain/`.
- Explains validator candidates, nominators, bonded stake, sessions, eras, staking elections, validator set rotation, rewards, commission, slashing, chilling, and unbonding.
- Adds a `demo-runbook.md` acceptance path so maintainers can verify genesis staking state, session-key readiness, validator candidate flow, nominations, era transition, active validator-set changes, payout, chill/unbond, and negative staking checks.
- Adds implementation and review checklists covering runtime wiring, genesis setup, learner walkthrough, tests, security review, maintainability, and evidence expectations.
- Uses official Polkadot staking, proof-of-stake consensus, FRAME staking pallet, and runtime customization references.

## Duplicate / attempt check

Immediately before opening this PR I checked issue #5 and this repository:

- issue #5 had zero comments.
- issue #5 had no assignee.
- this repository had no open PR matching Nominated Proof of Stake, NPoS, staking, or this course topic.

After this PR was opened, another contributor submitted a competing PR. This PR remains the earlier implementation PR and now includes a concrete local demo runbook to make maintainer acceptance easier to verify.

## Validation

- `git diff --check`
- `npx --yes markdownlint-cli@0.43.0 track-1/nominated-proof-of-stake-blockchain/*.md`
- ASCII/content scan
- conflict marker scan
- reference link HTTP status check: all listed links returned 200 before the original submission.

## Payout info

Payout details can be provided privately on acceptance.