### PR TITLE
Add Nominated Proof of Stake course module

### DIFF
--- a/track-1/substrate-nominated-proof-of-stake/README.md
+++ b/track-1/substrate-nominated-proof-of-stake/README.md
@@ -1,0 +1,493 @@
+# Substrate Nominated Proof of Stake Course
+
+This module shows how to design a Substrate-based chain that uses Nominated
+Proof of Stake. In an NPoS system, validators produce or finalize blocks, while
+nominators back validators with stake. The runtime uses that backing to choose an
+active validator set, distribute rewards, and apply slashing when validators
+misbehave.
+
+This course is a runtime design and implementation guide. It does not ask
+learners to copy Polkadot's production economics. Instead, learners build a
+small local chain that demonstrates bonding, nominating, validator selection,
+session rotation, rewards, and slashing with parameters that are easy to test.
+
+## Learning Goals
+
+After completing this module, a learner should be able to:
+
+- Explain the roles of validator, nominator, stash, controller, exposure, era,
+  and session.
+- Add the staking-related pallet set to a Substrate runtime.
+- Configure a small validator election for a local chain.
+- Wire staking to sessions so elected validators become consensus authorities.
+- Add local session keys for validators.
+- Bond funds, declare validator intent, nominate validators, and rotate the
+  active set.
+- Test rewards, slashes, chilling, unbonding, and withdrawal.
+- Explain which parameters are tutorial shortcuts and which require production
+  economic analysis.
+
+## Mental Model
+
+NPoS is easier to understand as a pipeline:
+
+```text
+accounts bond funds
+    |
+    v
+validators declare intent
+nominators choose validators
+    |
+    v
+staking pallet calculates exposures
+    |
+    v
+election provider selects active validators
+    |
+    v
+session pallet rotates validator set and session keys
+    |
+    v
+consensus pallets use the active authorities
+    |
+    v
+staking pays rewards or applies slashes by era
+```
+
+`pallet_staking` manages stake, roles, eras, exposures, rewards, slashes, and
+unbonding. `pallet_session` turns the elected validator set into the session
+authorities used by the consensus pallets. The election provider chooses the
+active validator set from validator candidates and nominator backing.
+
+## Core Terms
+
+### Validator
+
+A validator is a candidate to author or finalize blocks. Validators bond stake
+and must set session keys. If selected, they become part of the active set.
+
+### Nominator
+
+A nominator backs one or more validators with bonded stake. Nominators share in
+rewards and slash risk according to the runtime's staking rules.
+
+### Stash and Controller
+
+Many Substrate staking designs separate the stash account, which holds bonded
+funds, from the controller account, which sends staking operations. Recent
+runtime designs may simplify this pattern, so learners should check the SDK
+version they are using.
+
+### Era
+
+An era is the accounting period for staking rewards and slashes. Active exposure
+is usually calculated per era.
+
+### Session
+
+A session is the period over which a validator set and its session keys are
+active for consensus. Several sessions can fit inside one era.
+
+### Exposure
+
+Exposure is the stake behind an active validator, including the validator's own
+stake and nominator backing.
+
+## Repository Starting Point
+
+Start from a recent Polkadot SDK node template. Exact file names vary, but the
+work usually touches:
+
+```text
+runtime/
+  Cargo.toml
+  src/lib.rs
+  src/configs/
+  src/weights/
+node/
+  src/chain_spec.rs
+```
+
+This course assumes the chain already has:
+
+- `frame_system`;
+- `pallet_balances`;
+- a block authoring pallet such as BABE or Aura;
+- a finality pallet such as GRANDPA, when the template includes finality;
+- a local node service that can inject session keys.
+
+## Step 1: Choose the Local NPoS Scope
+
+Keep the first implementation small:
+
+```text
+desired validators: 2 or 3
+validator candidates: 4 or 5
+nominators: 4 to 8
+sessions per era: small enough for tests
+bonding duration: short enough for local verification
+slash: small but visible
+```
+
+This lets learners observe election, reward, and unbonding behavior without
+waiting for production-scale eras.
+
+## Step 2: Add Runtime Dependencies
+
+Minimum pallet set:
+
+```text
+pallet_staking
+pallet_session
+pallet_balances
+pallet_timestamp
+```
+
+Common supporting pallets:
+
+```text
+pallet_babe or pallet_aura
+pallet_grandpa
+pallet_authorship
+pallet_offences
+pallet_election_provider_multi_phase
+pallet_bags_list
+pallet_session_historical
+```
+
+For a learning chain, it is acceptable to start with a simpler election provider
+or a small on-chain election. For production-like NPoS, learners should study
+the current Polkadot SDK election provider and benchmarking requirements.
+
+Keep all dependencies in the same Polkadot SDK release family. Do not mix crate
+versions from different SDK releases.
+
+## Step 3: Configure Balances and Currency
+
+Staking needs a currency pallet because it reserves or locks stake. The course
+chain should define:
+
+- the native `Balance` type;
+- existential deposit;
+- staking currency type;
+- reward destination behavior;
+- slash destination behavior.
+
+The first test should prove that bonded funds cannot be freely transferred while
+they are locked for staking.
+
+## Step 4: Configure Session Keys
+
+Validators need session keys for the consensus pallets. A typical runtime has a
+session key type that combines authoring and finality keys:
+
+```rust
+impl_opaque_keys! {
+    pub struct SessionKeys {
+        pub babe: Babe,
+        pub grandpa: Grandpa,
+    }
+}
+```
+
+Templates that use Aura instead of BABE will use the Aura key instead. The
+course should teach the concept, not force a specific consensus engine.
+
+Local chain spec requirements:
+
+- each initial validator has a stash or validator account;
+- each validator has session keys;
+- genesis state contains the initial validator set;
+- the node can author blocks with the configured keys.
+
+## Step 5: Configure `pallet_session`
+
+The session pallet controls validator set rotation and session key assignment.
+Example shape:
+
+```rust
+impl pallet_session::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type ValidatorId = AccountId;
+    type ValidatorIdOf = StashOf<Self>;
+    type ShouldEndSession = Babe;
+    type NextSessionRotation = Babe;
+    type SessionManager = Staking;
+    type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
+    type Keys = SessionKeys;
+    type WeightInfo = pallet_session::weights::SubstrateWeight<Runtime>;
+}
+```
+
+The important invariant is that staking supplies the next validator set, while
+the consensus pallet decides session boundaries. Exact associated types depend on
+the chosen template and SDK version.
+
+## Step 6: Configure `pallet_staking`
+
+`pallet_staking` is the center of NPoS. It needs types for currency, rewards,
+sessions, election, offence handling, and operational limits.
+
+Example shape:
+
+```rust
+impl pallet_staking::Config for Runtime {
+    type Currency = Balances;
+    type CurrencyBalance = Balance;
+    type UnixTime = Timestamp;
+    type CurrencyToVote = CurrencyToVoteHandler;
+    type RewardRemainder = Treasury;
+    type RuntimeEvent = RuntimeEvent;
+    type Slash = Treasury;
+    type Reward = ();
+    type SessionsPerEra = SessionsPerEra;
+    type BondingDuration = BondingDuration;
+    type SlashDeferDuration = SlashDeferDuration;
+    type AdminOrigin = EnsureRoot<AccountId>;
+    type SessionInterface = Self;
+    type EraPayout = EraPayout;
+    type NextNewSession = Session;
+    type MaxNominations = MaxNominations;
+    type VoterList = BagsList;
+    type TargetList = Staking;
+    type ElectionProvider = ElectionProviderMultiPhase;
+    type GenesisElectionProvider = OnChainElectionProvider;
+    type MaxUnlockingChunks = MaxUnlockingChunks;
+    type HistoryDepth = HistoryDepth;
+    type BenchmarkingConfig = StakingBenchmarkingConfig;
+    type WeightInfo = pallet_staking::weights::SubstrateWeight<Runtime>;
+}
+```
+
+Do not treat this as copy-paste code. Staking configuration changes across SDK
+versions. The learner should use this as a map for what needs to be wired, then
+check the Rust docs for the exact trait in the selected release.
+
+## Step 7: Configure the Election Provider
+
+The election provider chooses active validators from candidates and nominations.
+A small learning chain can start with simple limits:
+
+```text
+MaxWinners: 3
+MaxBackersPerWinner: small value
+MaxNominations: small value
+ElectionLookahead: short
+```
+
+Production-like NPoS usually needs:
+
+- off-chain election workers;
+- signed or unsigned election submissions;
+- snapshot limits;
+- fallback behavior;
+- benchmarking for election weights;
+- monitoring when elections fail.
+
+Learners should add tests for:
+
+- too few validators;
+- more candidates than winners;
+- nominators backing multiple validators;
+- election result changes after stake changes.
+
+## Step 8: Add Bags List When Needed
+
+`pallet_bags_list` helps order voters by stake so staking can operate within
+bounded weight. In a tiny local chain, learners may not feel the need for it, but
+it is important when voter counts grow.
+
+Course guidance:
+
+- include it when using staking configs that expect `VoterList`;
+- configure bag thresholds for the local balance scale;
+- test that nominators can be inserted and repositioned;
+- document that production thresholds need chain-specific tuning.
+
+## Step 9: Add Offences and Slashing
+
+A chain should define what happens when validators equivocate or otherwise
+misbehave. The full offence pipeline depends on consensus choice, but the course
+should cover the staking-side result:
+
+- slash exposure;
+- defer slash when configured;
+- allow governance or admin cancellation during the defer period if the runtime
+  supports it;
+- reward reporters when applicable;
+- emit events that make the slash auditable.
+
+For local tests, use a controlled mock offence or staking test helper rather than
+trying to force a real consensus equivocation.
+
+## Step 10: Add Genesis Configuration
+
+A local chain should include:
+
+```text
+Alice validator candidate
+Bob validator candidate
+Charlie validator candidate
+Dave validator candidate
+Eve nominator
+Ferdie nominator
+```
+
+Genesis setup:
+
+- give each account enough balance;
+- bond validator stake;
+- set validator intent;
+- set session keys;
+- bond nominator stake;
+- add nominations;
+- set desired validator count.
+
+The first local run should produce blocks and rotate sessions without manual
+intervention.
+
+## Step 11: Run the Staking Flow
+
+Happy path:
+
+```text
+1. Alice and Bob bond funds.
+2. Alice and Bob call validate.
+3. Eve and Ferdie bond funds.
+4. Eve and Ferdie nominate Alice and Bob.
+5. The chain advances to the next election.
+6. Staking selects the active validator set.
+7. Session rotates to that validator set.
+8. Blocks continue to be produced.
+9. Era reward is paid.
+10. A nominator changes nominations.
+11. The next election reflects the changed backing.
+12. A validator chills and stops being selected.
+13. A bonded account unbonds and later withdraws.
+```
+
+Failure path:
+
+```text
+wrong session keys
+insufficient bond
+too many nominations
+too many unlocking chunks
+transfer of locked funds
+validator set below minimum
+election provider fallback
+slash event
+```
+
+## Step 12: Add Observability
+
+Learners should know which events and storage items prove the system works:
+
+- staking ledgers;
+- bonded account map;
+- validators;
+- nominators;
+- eras and sessions;
+- current elected exposures;
+- active session validators;
+- rewards and slashes;
+- unlocking chunks.
+
+The runbook should include commands or UI steps that inspect these values before
+and after the election.
+
+## Security and Economics Notes
+
+- Do not copy Polkadot's staking parameters without analysis.
+- Do not launch production NPoS without benchmarking election and staking
+  weights.
+- Do not make the minimum validator bond trivially cheap.
+- Do not set `MaxNominations` higher than the election provider can handle.
+- Do not ignore what happens when elections fail.
+- Do not forget session keys; a selected validator without usable keys hurts
+  liveness.
+- Do not make the slash fraction invisible in tests.
+- Do not shorten bonding duration so much that the economic signal is meaningless
+  in production.
+
+## Common Mistakes
+
+### Treating PoS and NPoS as the Same
+
+Pure PoS selects validators from their own stake. NPoS adds nominator backing and
+spreads stake across selected validators. That extra nomination layer is the main
+topic of this module.
+
+### Wiring Staking Without Sessions
+
+If staking elects validators but sessions never rotate to them, the elected set
+does not become the consensus authority set.
+
+### Ignoring Election Limits
+
+Validator and nominator counts must stay within configured limits. A tutorial can
+use small numbers, but production chains need realistic stress tests.
+
+### Skipping Key Management
+
+Validators need session keys. A candidate with bonded stake but missing session
+keys should not be treated as a healthy validator.
+
+### Hiding Slashing
+
+NPoS is not only rewards. Learners must see what risk validators and nominators
+take when backing a validator.
+
+## Suggested Tests
+
+Unit tests:
+
+- bonding reserves or locks funds;
+- validator intent is recorded;
+- nomination list is recorded;
+- too many nominations fail;
+- election selects the expected winners in a small deterministic setup;
+- session rotates to the elected validators;
+- reward payout updates balances or reward destinations;
+- slash reduces exposure;
+- chilling removes validator intent;
+- unbonding creates an unlocking chunk;
+- withdrawal works only after the bonding duration;
+- locked funds cannot be transferred.
+
+End-to-end local node checks:
+
+- start a local chain with at least two validators;
+- inspect current session validators;
+- submit nominations from two accounts;
+- advance through at least one era;
+- verify the active set and exposures;
+- trigger or simulate a slash in a controlled test environment;
+- chill one validator and verify the later active set changes;
+- unbond and withdraw after the configured delay.
+
+## Learner Deliverables
+
+At the end of the module, the learner should submit:
+
+- a design note with validator count, session length, era length, bonding
+  duration, slashing policy, and election limits;
+- runtime configuration for staking, session, election, and supporting pallets;
+- genesis configuration for validators, nominators, balances, and session keys;
+- tests for bonding, nominating, election, session rotation, reward, slash, and
+  unbonding;
+- a local runbook that demonstrates the full staking lifecycle;
+- logs or screenshots proving that nominations affect the active validator set.
+
+## References
+
+- Polkadot staking overview:
+  <https://wiki.polkadot.com/learn/learn-staking/>
+- `pallet_staking` Rust docs:
+  <https://paritytech.github.io/polkadot-sdk/master/pallet_staking/>
+- `pallet_session` Rust docs:
+  <https://paritytech.github.io/polkadot-sdk/master/pallet_session/>
+- `pallet_election_provider_multi_phase` Rust docs:
+  <https://paritytech.github.io/polkadot-sdk/master/pallet_election_provider_multi_phase/>
+- Add an existing pallet to a runtime:
+  <https://docs.polkadot.com/parachains/customize-runtime/add-existing-pallets/>

--- a/track-1/substrate-nominated-proof-of-stake/README.md
+++ b/track-1/substrate-nominated-proof-of-stake/README.md
@@ -396,6 +396,15 @@ Learners should know which events and storage items prove the system works:
 The runbook should include commands or UI steps that inspect these values before
 and after the election.
 
+## Local Acceptance Runbook
+
+Use [demo-runbook.md](demo-runbook.md) as the maintainer acceptance path. It
+shows the storage items, events, extrinsics, and negative checks that prove the
+course chain is more than explanatory text. A complete submission should attach
+the runbook output, logs, or screenshots to show that nominations change later
+validator exposure and that rewards, slashes, chilling, unbonding, and locked
+transfer failures are observable.
+
 ## Security and Economics Notes
 
 - Do not copy Polkadot's staking parameters without analysis.

--- a/track-1/substrate-nominated-proof-of-stake/demo-runbook.md
+++ b/track-1/substrate-nominated-proof-of-stake/demo-runbook.md
@@ -1,0 +1,241 @@
+# Local NPoS Demo Runbook
+
+This runbook gives maintainers and learners a concrete acceptance path for a
+local Nominated Proof of Stake course chain. It assumes a Polkadot SDK node
+template with staking, session, balances, timestamp, election, and consensus
+pallets wired into the runtime.
+
+The exact binary name and account model can change by SDK release. Replace
+`node-template` and the example account names with the names used by the course
+implementation.
+
+## Acceptance Goal
+
+The local demo should prove these behaviors:
+
+- Genesis contains funded validator and nominator accounts.
+- Validators have session keys before they can be healthy authorities.
+- Validators can bond funds and declare validator intent.
+- Nominators can bond funds and nominate validator candidates.
+- The election provider selects a bounded active validator set.
+- Session rotation moves the elected set into the active authorities.
+- Rewards are observable after an era.
+- Slashes are observable through a controlled test or mock offence.
+- Chilling, unbonding, and withdrawal work with the configured delay.
+- Locked stake cannot be transferred freely.
+
+## Suggested Local Parameters
+
+Use short tutorial constants so the lifecycle is observable in one local run:
+
+| Parameter | Suggested value |
+| --- | --- |
+| Desired validators | 2 |
+| Validator candidates | 4 |
+| Nominators | 2 to 4 |
+| Sessions per era | 2 |
+| Bonding duration | 1 to 2 eras |
+| Max nominations | 2 to 4 |
+| Slash fraction | Small but visible |
+
+Document that these values are tutorial settings, not production economics.
+
+## 1. Build and Start From a Clean Chain
+
+Build the node:
+
+```bash
+cargo build --release
+```
+
+Purge old local state before each acceptance run:
+
+```bash
+./target/release/node-template purge-chain --dev -y
+```
+
+Start the tutorial chain:
+
+```bash
+./target/release/node-template --dev --tmp
+```
+
+For a multi-validator demo, generate a local chain spec, insert session keys for
+each validator node, and start each validator with the same chain spec. The
+course should include the exact command names used by the chosen template.
+
+## 2. Verify Genesis Staking State
+
+Before sending any extrinsic, record the initial state:
+
+- `staking.validatorCount`
+- `staking.validators`
+- `staking.bonded`
+- `staking.ledger`
+- `staking.nominators`
+- `session.validators`
+- `session.nextKeys`
+- `balances.account`
+
+Expected evidence:
+
+| Check | Expected result |
+| --- | --- |
+| Validator accounts are funded | Free balance is above the validator bond |
+| Nominator accounts are funded | Free balance is above the nominator bond |
+| Initial validators are bonded | `staking.ledger` exists |
+| Session keys exist | `session.nextKeys` exists for validators |
+| Node produces blocks | New blocks appear without manual intervention |
+
+## 3. Register Validator Candidates
+
+For each validator candidate:
+
+1. Bond stake with the configured reward destination.
+2. Set session keys if the template does not insert them at genesis.
+3. Call `staking.validate` with a visible commission value.
+4. Query `staking.validators` and confirm the validator preferences.
+
+Record these events:
+
+- `staking.Bonded`
+- `session.NewSession` or the template equivalent
+- `staking.ValidatorPrefsSet`, when emitted by the SDK version
+
+Negative check:
+
+- Try to validate with insufficient bond and confirm the dispatch fails.
+
+## 4. Add Nominations
+
+For each nominator:
+
+1. Bond nominator stake.
+2. Nominate one or more validator candidates.
+3. Query `staking.nominators`.
+4. Confirm the nomination target list is bounded by `MaxNominations`.
+
+Record these events:
+
+- `staking.Bonded`
+- `staking.Nominated`
+
+Negative checks:
+
+- Nominate more targets than `MaxNominations`.
+- Nominate an account that is not an eligible validator candidate.
+- Try to transfer bonded stake and confirm the locked transfer fails.
+
+## 5. Advance Sessions and Eras
+
+Wait until the configured number of sessions has passed, or use a test harness
+that advances blocks to the next era.
+
+Record these values before and after advancement:
+
+- `session.currentIndex`
+- `session.validators`
+- `staking.activeEra`
+- `staking.currentEra`
+- `staking.erasStakers` or the SDK release equivalent
+- `staking.erasValidatorPrefs`
+
+Expected evidence:
+
+- The active validator set matches the election output.
+- Exposure includes validator self stake and nominator backing.
+- A nomination change affects a later election, not the already-active era.
+
+## 6. Prove Reward Payout
+
+After at least one rewardable era:
+
+1. Capture validator and nominator balances.
+2. Call `staking.payoutStakers` for a validator and era when the runtime uses
+   explicit payout.
+3. Query balances and staking ledgers again.
+4. Capture reward-related events.
+
+Expected evidence:
+
+- Reward destination behavior matches the runtime configuration.
+- Validator commission is visible when commission is nonzero.
+- Nominator reward share changes with exposure.
+
+## 7. Prove Slashing Behavior
+
+For a local course, prefer a controlled runtime test or mock offence over trying
+to force a real consensus equivocation.
+
+The evidence packet should include:
+
+- the offence or slash trigger used by the test;
+- the validator exposure before the slash;
+- slash-related events;
+- validator and nominator balances or ledgers after the slash;
+- whether the slash is immediate or deferred;
+- any governance or admin cancellation path, if configured.
+
+Expected evidence:
+
+- Validator stake is reduced.
+- Nominator-backed exposure is affected according to the runtime's staking
+  rules.
+- The slash amount is large enough to see in balances or events.
+
+## 8. Chill, Unbond, and Withdraw
+
+For one validator:
+
+1. Call `staking.chill`.
+2. Advance to a later election.
+3. Confirm the validator is no longer selected when enough candidates remain.
+
+For one bonded account:
+
+1. Call `staking.unbond`.
+2. Query the unlocking chunk in `staking.ledger`.
+3. Try `withdrawUnbonded` before the bonding duration ends and confirm it does
+   not release funds early.
+4. Advance past the bonding duration.
+5. Call `withdrawUnbonded`.
+6. Confirm the free balance and ledger state.
+
+Expected evidence:
+
+- Chilling removes validator intent.
+- Unbonding creates an unlocking chunk.
+- Withdrawal respects the configured delay.
+
+## 9. Required Evidence Packet
+
+A submission is easy to review when it includes:
+
+- the local constants used for the demo;
+- the chain spec or genesis snippet for staking and session keys;
+- commands used to start the node;
+- storage snapshots before and after nomination;
+- storage snapshots before and after session or era rotation;
+- reward payout events and balance changes;
+- slash test output;
+- chill, unbond, and withdrawal output;
+- failing negative checks for insufficient bond, too many nominations, and
+  locked transfer.
+
+## 10. Maintainer Review Checklist
+
+Use this checklist to accept or reject the local demo:
+
+- [ ] The runtime compiles.
+- [ ] The local node produces blocks.
+- [ ] Session keys are present for validators.
+- [ ] Validators can bond and validate.
+- [ ] Nominators can bond and nominate.
+- [ ] Election output is visible.
+- [ ] Session rotation uses the elected validators.
+- [ ] Reward payout is visible.
+- [ ] Slash behavior is visible.
+- [ ] Chilling changes later validator selection.
+- [ ] Unbonding and withdrawal respect bonding duration.
+- [ ] Locked stake transfer fails.
+- [ ] Tutorial constants are clearly marked as non-production values.

--- a/track-1/substrate-nominated-proof-of-stake/implementation-checklist.md
+++ b/track-1/substrate-nominated-proof-of-stake/implementation-checklist.md
@@ -1,0 +1,134 @@
+# Implementation Checklist
+
+Use this checklist while building the Nominated Proof of Stake course chain.
+
+## Design
+
+- [ ] Define the local validator count.
+- [ ] Define the candidate count.
+- [ ] Define the nominator count.
+- [ ] Define session length.
+- [ ] Define sessions per era.
+- [ ] Define bonding duration.
+- [ ] Define slash defer duration.
+- [ ] Define maximum nominations per nominator.
+- [ ] Define election limits.
+- [ ] Document which parameters are tutorial shortcuts.
+
+## Dependencies
+
+- [ ] Add `pallet_staking`.
+- [ ] Add `pallet_session`.
+- [ ] Add `pallet_balances`.
+- [ ] Add `pallet_timestamp`.
+- [ ] Add a block authoring pallet such as BABE or Aura.
+- [ ] Add GRANDPA if the template uses finality.
+- [ ] Add `pallet_authorship` when rewards or authorship tracking need it.
+- [ ] Add `pallet_offences` for offence reporting.
+- [ ] Add `pallet_election_provider_multi_phase` for production-like elections.
+- [ ] Add `pallet_bags_list` when the staking config expects a voter list.
+- [ ] Keep all pallets in the same Polkadot SDK release family.
+
+## Balances
+
+- [ ] Define `Balance`.
+- [ ] Define existential deposit.
+- [ ] Configure balances as staking currency.
+- [ ] Test that bonded funds cannot be transferred freely.
+- [ ] Test reward destination behavior.
+- [ ] Test slash destination behavior.
+
+## Session Keys
+
+- [ ] Define the runtime `SessionKeys` type.
+- [ ] Include the authoring key type.
+- [ ] Include the finality key type if applicable.
+- [ ] Add keys for every genesis validator.
+- [ ] Verify the node can author blocks with those keys.
+- [ ] Test that missing or wrong keys are visible in local verification.
+
+## Session Pallet
+
+- [ ] Configure validator ID.
+- [ ] Configure validator ID lookup.
+- [ ] Configure session ending logic.
+- [ ] Configure next session rotation.
+- [ ] Configure `SessionManager = Staking`.
+- [ ] Configure session handler.
+- [ ] Configure session keys.
+- [ ] Add the pallet to the runtime construct with a unique pallet index.
+- [ ] Test session rotation.
+
+## Staking Pallet
+
+- [ ] Configure currency.
+- [ ] Configure vote conversion.
+- [ ] Configure rewards.
+- [ ] Configure slashing.
+- [ ] Configure sessions per era.
+- [ ] Configure bonding duration.
+- [ ] Configure slash defer duration.
+- [ ] Configure admin or governance origin.
+- [ ] Configure session interface.
+- [ ] Configure era payout.
+- [ ] Configure election provider.
+- [ ] Configure genesis election provider.
+- [ ] Configure maximum nominations.
+- [ ] Configure voter list.
+- [ ] Configure target list.
+- [ ] Configure history depth.
+- [ ] Add the pallet to the runtime construct with a unique pallet index.
+
+## Election Provider
+
+- [ ] Configure maximum winners.
+- [ ] Configure maximum backers per winner.
+- [ ] Configure election lookahead.
+- [ ] Configure snapshot limits.
+- [ ] Configure fallback behavior.
+- [ ] Benchmark or document weight limits.
+- [ ] Test deterministic election results in a small setup.
+- [ ] Test behavior when there are too few candidates.
+- [ ] Test behavior when nominator backing changes.
+
+## Genesis
+
+- [ ] Fund validator accounts.
+- [ ] Fund nominator accounts.
+- [ ] Bond validator funds.
+- [ ] Mark validator accounts as candidates.
+- [ ] Add session keys.
+- [ ] Bond nominator funds.
+- [ ] Add nominations.
+- [ ] Set desired validator count.
+- [ ] Start the node and verify initial authorities.
+
+## Tests
+
+- [ ] Bonding works.
+- [ ] Validator intent works.
+- [ ] Nominations work.
+- [ ] Too many nominations fail.
+- [ ] Election selects expected winners.
+- [ ] Session rotates to elected validators.
+- [ ] Rewards are paid.
+- [ ] Slashes are applied.
+- [ ] Chilling works.
+- [ ] Unbonding creates unlocking chunks.
+- [ ] Withdrawal respects bonding duration.
+- [ ] Locked stake cannot be transferred.
+
+## Local Runbook
+
+- [ ] Start local chain.
+- [ ] Inspect initial validators.
+- [ ] Submit validator intent.
+- [ ] Submit nominations.
+- [ ] Advance sessions.
+- [ ] Advance eras.
+- [ ] Inspect exposures.
+- [ ] Inspect rewards.
+- [ ] Simulate or test a slash.
+- [ ] Chill a validator.
+- [ ] Unbond and withdraw.
+- [ ] Capture logs or screenshots for each lifecycle stage.

--- a/track-1/substrate-nominated-proof-of-stake/review-checklist.md
+++ b/track-1/substrate-nominated-proof-of-stake/review-checklist.md
@@ -1,0 +1,95 @@
+# Review Checklist
+
+Use this checklist to review a learner's Nominated Proof of Stake implementation
+before accepting the module.
+
+## Conceptual Accuracy
+
+- [ ] The submission distinguishes PoS from NPoS.
+- [ ] It defines validators.
+- [ ] It defines nominators.
+- [ ] It defines stash and controller accounts, or explains the SDK version's
+      current account model.
+- [ ] It defines sessions.
+- [ ] It defines eras.
+- [ ] It defines exposure.
+- [ ] It explains how nominations affect validator selection.
+- [ ] It explains reward and slash sharing.
+
+## Runtime Wiring
+
+- [ ] Staking is configured.
+- [ ] Session is configured.
+- [ ] Balances are configured as staking currency.
+- [ ] Timestamp is configured when required.
+- [ ] Consensus pallets are compatible with session keys.
+- [ ] Election provider is configured.
+- [ ] Bags list is configured when required.
+- [ ] Offences or slashing path is configured.
+- [ ] Runtime pallet indices are unique.
+- [ ] The configuration matches one Polkadot SDK release family.
+
+## Session and Consensus
+
+- [ ] Validators have session keys.
+- [ ] Genesis validators can author blocks.
+- [ ] Staking provides the session manager.
+- [ ] Session rotation changes the active authority set.
+- [ ] Missing or invalid keys are handled visibly.
+
+## Election Behavior
+
+- [ ] The desired validator count is documented.
+- [ ] Candidate limits are documented.
+- [ ] Nominator limits are documented.
+- [ ] A deterministic small election is tested.
+- [ ] Too few validators is tested.
+- [ ] Too many nominations is tested.
+- [ ] Changing stake or nominations changes later exposure where expected.
+- [ ] Election fallback behavior is documented.
+
+## Economics and Safety
+
+- [ ] Bonding duration is documented.
+- [ ] Slash defer duration is documented.
+- [ ] Reward destination behavior is documented.
+- [ ] Slash destination behavior is documented.
+- [ ] Bonded funds cannot be transferred freely.
+- [ ] Slashing affects validator and nominator exposure.
+- [ ] Tutorial constants are not presented as production economics.
+- [ ] Weight and benchmarking requirements are mentioned.
+
+## Tests
+
+- [ ] Bonding is tested.
+- [ ] Validator intent is tested.
+- [ ] Nominations are tested.
+- [ ] Election is tested.
+- [ ] Session rotation is tested.
+- [ ] Reward payout is tested.
+- [ ] Slashing is tested.
+- [ ] Chilling is tested.
+- [ ] Unbonding is tested.
+- [ ] Withdrawal after bonding duration is tested.
+- [ ] Locked transfer failure is tested.
+
+## Documentation Quality
+
+- [ ] The course can be followed from a clean template.
+- [ ] Code snippets are clearly marked as release-dependent shapes when they are
+      not exact drop-in code.
+- [ ] The local runbook demonstrates the full staking lifecycle.
+- [ ] The module links to Polkadot or Polkadot SDK references.
+- [ ] Common mistakes are documented.
+- [ ] Production caveats are visible.
+
+## Acceptance Criteria
+
+- [ ] The runtime compiles.
+- [ ] The tests pass.
+- [ ] A local node can produce blocks.
+- [ ] Validators and nominators can bond funds.
+- [ ] Nominations affect election results.
+- [ ] Sessions rotate to the elected validator set.
+- [ ] Rewards and slashes are observable.
+- [ ] Unbonding and withdrawal work after the configured delay.


### PR DESCRIPTION
Submission for #5 (250 USD OpenGuild bounty).

## What changed

- Adds a Track 1 Nominated Proof of Stake course module under `track-1/substrate-nominated-proof-of-stake/`.
- Explains the NPoS pipeline: bonding, validator intent, nominations, exposures, election, session rotation, consensus authority handoff, rewards, slashing, chilling, unbonding, and withdrawal.
- Documents a local runtime design covering `pallet_staking`, `pallet_session`, balances, consensus/session keys, election provider, bags-list, offences, genesis config, observability, and production caveats.
- Adds implementation and review checklists for runtime wiring, session/consensus integration, election behavior, economics, tests, and local runbook evidence.

## Duplicate / attempt check

When I started this submission, issue #5 was open, had zero comments, and had no assignee. I posted an in-progress note here before finishing validation:

- https://github.com/openguild-labs/open-contribution-bounty/issues/5#issuecomment-4431613697

During final validation and push, another PR for the same bounty appeared (#53). I am still submitting this PR because this implementation was already in progress from the earlier note, and the maintainer can compare the two submissions.

## Validation

- `git diff --cached --check` before commit
- `git diff --check -- track-1/substrate-nominated-proof-of-stake`
- `LC_ALL=C rg -n "[^\\x00-\\x7F]" track-1/substrate-nominated-proof-of-stake || true`
- `npx --yes markdownlint-cli@0.43.0 track-1/substrate-nominated-proof-of-stake/*.md`
- Reference link HTTP status check: all listed links returned 200.

## Payout info

- Payout details can be provided from `william08190` on acceptance.
