### PR TITLE
Add Polkadot and Kusama comparison blog

### DIFF
--- a/track-3/polkadot-kusama-differences/README.md
+++ b/track-3/polkadot-kusama-differences/README.md
@@ -208,6 +208,29 @@ This workflow treats Kusama as a real production stage, not a casual sandbox.
 It also protects Polkadot users from designs that have not yet faced live
 network conditions.
 
+## Launch readiness questions
+
+Before choosing a network, a team should answer a few concrete questions:
+
+- Has the runtime, application, or XCM flow already been tested on a local
+  chain and a public testnet?
+- Does the team need live governance and economic feedback before a stable
+  launch?
+- Can the team monitor runtime upgrades, governance activity, validator or
+  collator health, indexers, wallets, and user-facing incidents?
+- Is the expected user base comfortable with faster iteration and higher
+  volatility, or does it require a more conservative production surface?
+- Can the team support two communities and two release tracks if it chooses
+  both networks?
+- Are migration, incident response, and communication plans written before
+  value-bearing users are exposed?
+
+If the answers point to learning under real conditions, Kusama may be the
+right first production stage. If the answers point to mature operations,
+conservative users, and a hardened design, Polkadot may be the better target.
+If the team cannot monitor or communicate changes on either network, it should
+keep rehearsing on local and testnet environments first.
+
 ## Summary
 
 Polkadot and Kusama are complementary networks. Polkadot is the stable,

--- a/track-3/polkadot-kusama-differences/README.md
+++ b/track-3/polkadot-kusama-differences/README.md
@@ -1,0 +1,229 @@
+# Polkadot and Kusama: Exploring the Differences
+
+Polkadot and Kusama are often described together because they share much of
+the same technology stack, but they are not interchangeable networks. A useful
+mental model is that Polkadot is the conservative production network and
+Kusama is the faster-moving canary network. Both are live, permissionless,
+value-bearing networks with their own token, governance, validator set, and
+community.
+
+That distinction matters for builders. A team choosing between the two is not
+choosing between "real mainnet" and "throwaway testnet". It is choosing between
+two production environments with different risk tolerance, cost profile,
+upgrade speed, and ecosystem expectations.
+
+## Shared technical foundation
+
+Both networks are built from the Polkadot SDK and use the same broad
+architecture:
+
+- A relay-chain model that coordinates shared security and consensus.
+- Parachain and system-chain execution environments connected through the
+  broader Polkadot protocol.
+- Native staking, validator selection, and nominated proof-of-stake mechanics.
+- On-chain governance for runtime upgrades, treasury decisions, and network
+  parameter changes.
+- Cross-chain messaging capabilities through XCM and related ecosystem
+  infrastructure.
+
+Because the codebase and architecture are closely related, many technical
+lessons transfer between the networks. A runtime upgrade, parachain design, XCM
+flow, governance proposal, or operational pattern tested on Kusama can often
+inform a later Polkadot deployment. The transfer is not automatic, though:
+governance parameters, risk appetite, economic conditions, and community norms
+can differ enough that teams should still validate assumptions separately on
+each network.
+
+## The core difference: risk and release philosophy
+
+Polkadot prioritizes stability and dependability. It is the network teams
+usually target when they need the most conservative production environment in
+the ecosystem. Changes are still possible through on-chain governance, but the
+network culture and parameter choices are tuned toward reliability.
+
+Kusama prioritizes speed, experimentation, and earlier exposure to real-world
+conditions. It is a canary network, meaning new protocol changes and ecosystem
+ideas can appear there before they are considered mature enough for Polkadot.
+This makes Kusama valuable precisely because it is not a mock environment:
+validators, nominators, token holders, builders, and users all interact under
+live economic incentives.
+
+The tradeoff is straightforward:
+
+- Polkadot gives teams a more stable production target.
+- Kusama gives teams a faster feedback loop and a lower-stakes environment for
+  real economic experimentation.
+
+## Kusama is not just a testnet
+
+Calling Kusama a "testnet" hides its most important property. Testnets are
+usually resettable, faucet-funded, and economically lightweight. Kusama has its
+own token, its own governance, and its own community. It is designed for
+experimentation, but changes still affect real users and real economic value.
+
+That makes Kusama sit between two extremes:
+
+- It is more serious than a testnet because failures cost real money,
+  reputation, and operational effort.
+- It is more forgiving than Polkadot because the ecosystem expects faster
+  iteration and higher risk.
+
+This is why many teams use a staged path:
+
+1. Build and test locally or on a testnet.
+2. Deploy to Kusama to observe behavior in a live, decentralized environment.
+3. Harden the design before deploying to Polkadot.
+
+Some teams keep deployments on both networks. Others stay on Kusama because
+their product benefits from rapid experimentation more than maximum
+conservatism.
+
+## Governance speed and upgrade cadence
+
+One of the clearest operational differences is governance speed. The Polkadot
+Wiki notes that Kusama has modified governance parameters that allow upgrades
+and governance events to move faster than on Polkadot. This does not mean
+Kusama has inherently faster block production or transaction throughput. The
+important difference is the time between proposing, voting, and enacting
+changes.
+
+For protocol teams, this means Kusama can shorten the loop between a proposed
+runtime change and live production feedback. For users and operators, it also
+means the network can change more frequently. Validators, indexers, wallets,
+and application teams need to watch governance and runtime release channels
+more actively on Kusama.
+
+On Polkadot, slower governance cadence is a feature for teams that need more
+predictable operational windows and stronger confidence before adopting
+changes.
+
+## Cost, economic stakes, and launch strategy
+
+Kusama has historically been the more affordable place to experiment. The
+Polkadot Wiki describes Kusama as having lower bonding requirements for teams
+that want to run parachains, making it a more accessible development
+environment. Even as coretime and other resource-allocation mechanics evolve,
+the strategic difference remains: Kusama is generally the place where teams can
+take more risk and iterate with lower economic pressure.
+
+Polkadot is better suited when a project has stronger requirements around
+brand trust, liquidity, long-term support, and conservative execution. Kusama
+is better suited when the project needs to learn quickly, test governance or
+token mechanics, expose a new protocol design to real users, or launch before
+the design is fully hardened.
+
+## Security posture and failure tolerance
+
+Both networks rely on serious validator and governance infrastructure, but the
+failure tolerance is different.
+
+On Polkadot, the cost of a mistake is higher because users expect a more stable
+environment. Teams should treat Polkadot releases as production-grade changes:
+thorough test coverage, migration plans, upgrade rehearsals, monitoring,
+rollback thinking, and clear governance communication.
+
+On Kusama, mistakes are still real, but the network's purpose makes
+experimentation more acceptable. This makes Kusama useful for:
+
+- Testing runtime upgrades with live validators.
+- Validating XCM and cross-chain assumptions with real assets.
+- Proving governance, treasury, and community processes.
+- Running early parachain or application deployments.
+- Stress-testing operational playbooks before a Polkadot launch.
+
+The right conclusion is not that Kusama is unsafe. The right conclusion is
+that Kusama is optimized for different kinds of safety: discovery, iteration,
+and early failure under real conditions.
+
+## Developer decision matrix
+
+Choose Polkadot when:
+
+- The product needs maximum stability and ecosystem trust.
+- The team has already validated its runtime, chain, or application design.
+- The user base expects conservative upgrades and lower volatility.
+- The project is handling higher-value use cases where mistakes are less
+  acceptable.
+- The deployment should be positioned as the primary long-term production
+  environment.
+
+Choose Kusama when:
+
+- The project is early, experimental, or governance-heavy.
+- The team needs faster runtime and governance iteration.
+- The design benefits from real users and real economic signals before a
+  Polkadot launch.
+- The team wants to test an upgrade or migration path before using it on
+  Polkadot.
+- The product's community values experimentation and can tolerate higher
+  volatility.
+
+Use both when:
+
+- Kusama can serve as the early release network and Polkadot as the stable
+  release network.
+- The project has separate audiences for experimental and conservative
+  deployments.
+- The team wants to validate XCM, governance, staking, or runtime behavior in
+  stages.
+
+## Common misconceptions
+
+### "Kusama is only a testnet"
+
+Kusama is a live network with its own token and governance. It can be used for
+testing, but it is not equivalent to a faucet-funded development network.
+
+### "Polkadot and Kusama always run the same features"
+
+The networks are closely related, but they are independent. Kusama may receive
+features earlier, and governance can take each network in a different
+direction.
+
+### "Faster governance means faster blocks"
+
+The key difference is governance and upgrade timing, not necessarily block time
+or raw throughput.
+
+### "Every project should launch on both"
+
+Dual deployment is useful for many teams, but it adds operational overhead.
+Teams should only run both networks when they can support both communities,
+monitoring surfaces, releases, and governance processes.
+
+## Practical workflow for builders
+
+A disciplined launch workflow can use the strengths of each network:
+
+1. Prototype locally and on testnets until the core behavior is deterministic.
+2. Write migration and rollback notes before any value-bearing deployment.
+3. Launch on Kusama when the team needs live economic and governance feedback.
+4. Track metrics, user behavior, governance feedback, XCM behavior, and
+   operational incidents.
+5. Fix issues and harden monitoring.
+6. Launch on Polkadot only when the team can justify the higher stability
+   expectation.
+
+This workflow treats Kusama as a real production stage, not a casual sandbox.
+It also protects Polkadot users from designs that have not yet faced live
+network conditions.
+
+## Summary
+
+Polkadot and Kusama are complementary networks. Polkadot is the stable,
+conservative production environment. Kusama is the fast-moving canary network
+where teams can experiment under real economic conditions. They share enough
+technology that learning transfers between them, but they differ enough that a
+deployment strategy should account for governance speed, risk appetite, cost,
+community expectations, and operational maturity.
+
+The best builders do not ask which network is "better". They ask which network
+matches the current maturity and risk profile of the thing they are shipping.
+
+## References
+
+- [Polkadot Wiki: Polkadot vs. Kusama](https://wiki.polkadot.network/learn/learn-comparisons-kusama/)
+- [Polkadot Wiki: Getting Started with Kusama](https://wiki.polkadot.network/kusama/kusama-getting-started/)
+- [Polkadot Developer Docs: Networks](https://docs.polkadot.com/polkadot-protocol/basics/networks/)
+- [Polkadot Developer Docs: On-Chain Governance](https://docs.polkadot.com/reference/governance)
+- [Kusama Network](https://kusama.network/)

--- a/track-3/polkadot-kusama-differences/review-checklist.md
+++ b/track-3/polkadot-kusama-differences/review-checklist.md
@@ -1,0 +1,43 @@
+# Review Checklist
+
+Use this checklist to review the Polkadot and Kusama comparison before
+publishing or accepting it as a Track 3 technical blog submission.
+
+## Source accuracy
+
+- The article clearly states that Polkadot and Kusama are independent,
+  value-bearing networks.
+- The article does not describe Kusama as a disposable testnet.
+- The article distinguishes governance speed from block time or raw
+  throughput.
+- The article avoids hardcoded parameter values that can drift through
+  governance unless they are sourced and current.
+- The references point to official Polkadot or Kusama resources.
+
+## Technical completeness
+
+- The shared relay-chain, parachain, governance, staking, and XCM context is
+  explained at a high level.
+- The main differences are covered: risk tolerance, governance cadence,
+  deployment strategy, cost profile, and community expectations.
+- The article explains when a team might choose Polkadot, Kusama, or both.
+- The article includes common misconceptions and corrects them directly.
+
+## Builder usefulness
+
+- The article gives a practical decision matrix instead of only describing
+  branding differences.
+- The staged launch workflow is realistic for builders moving from testnets to
+  Kusama and Polkadot.
+- The tone is neutral and does not treat either network as universally better.
+- The article makes the risk tradeoff explicit for teams choosing a launch
+  network.
+
+## Editorial quality
+
+- Headings are descriptive and easy to scan.
+- The article avoids unsupported price, market-cap, or speculative investment
+  claims.
+- The text is readable for technically curious builders without requiring deep
+  prior Polkadot knowledge.
+- Markdown formatting is consistent and link text is descriptive.

--- a/track-3/polkadot-kusama-differences/review-checklist.md
+++ b/track-3/polkadot-kusama-differences/review-checklist.md
@@ -21,6 +21,8 @@ publishing or accepting it as a Track 3 technical blog submission.
 - The main differences are covered: risk tolerance, governance cadence,
   deployment strategy, cost profile, and community expectations.
 - The article explains when a team might choose Polkadot, Kusama, or both.
+- The article includes launch-readiness questions that connect network choice
+  to testing, monitoring, user expectations, and incident response.
 - The article includes common misconceptions and corrects them directly.
 
 ## Builder usefulness
@@ -29,6 +31,8 @@ publishing or accepting it as a Track 3 technical blog submission.
   branding differences.
 - The staged launch workflow is realistic for builders moving from testnets to
   Kusama and Polkadot.
+- The readiness questions help builders decide whether they are prepared for
+  either value-bearing network.
 - The tone is neutral and does not treat either network as universally better.
 - The article makes the risk tradeoff explicit for teams choosing a launch
   network.


### PR DESCRIPTION
Submission for #23 ($40 OpenGuild Track 3 technical blog bounty).

## What changed

- Added a standalone technical blog under `track-3/polkadot-kusama-differences/`.
- Compared Polkadot and Kusama across shared architecture, canary-network role, governance cadence, cost/risk profile, launch strategy, and builder decision criteria.
- Added a review checklist for source accuracy, technical completeness, builder usefulness, and editorial quality.

## Duplicate / attempt check

Immediately before opening this PR I checked issue #23 and this repository:

- issue #23 is still open, has no assignee, and still carries the `Available` bounty label.
- issue #23 contains an older external Google Docs submission from 2024 and a later interest comment, but I found no open or closed in-repository PR matching #23, Kusama, or the Polkadot/Kusama comparison topic.
- this PR provides an in-repository Markdown submission so maintainers can review it directly with the rest of the bounty content.

## Validation

- `git diff --cached --check`
- `git diff --check -- track-3/polkadot-kusama-differences`
- `LC_ALL=C rg -n '[^\\x00-\\x7F]' track-3/polkadot-kusama-differences`
- `npx --yes markdownlint-cli@0.43.0 track-3/polkadot-kusama-differences/*.md`
- Reference link HTTP status check: all listed links returned 200, with normal Polkadot docs/wiki canonical redirects.

## Payout info

- Payout details can be provided from `zaixincheng174-ai` on acceptance.

Closes #23
