### PR TITLE
Add Polkadot networking protocol blog

### DIFF
--- a/track-3/polkadot-networking-protocol/README.md
+++ b/track-3/polkadot-networking-protocol/README.md
@@ -107,6 +107,51 @@ peer network so block producers can include them.
 Fourth, it serves data to other peers. A well-connected full node is not only a
 consumer of network data. It can also help other peers sync and stay healthy.
 
+## Message flow examples
+
+Three concrete flows make the networking model easier to review.
+
+### A new full node catches up
+
+1. The node starts with a chain specification and discovers initial peers
+   through bootnodes or reserved peers.
+2. It negotiates supported protocols with connected peers.
+3. It requests headers, blocks, and state data needed for sync.
+4. It imports valid blocks locally and updates best and finalized block state.
+5. After catching up, it continues listening for new blocks and serving useful
+   data to other peers.
+
+If this flow fails, check chain specification, bootnode reachability, P2P
+listening address, firewall rules, disk performance, and node version before
+assuming a consensus problem.
+
+### A submitted transaction reaches block producers
+
+1. A wallet, script, or application submits an extrinsic through RPC.
+2. The receiving node validates it enough to place it in the transaction pool.
+3. The transaction is gossiped to peers according to the node's networking and
+   transaction-pool behavior.
+4. A block producer can include the transaction if it is still valid and
+   eligible for the block being built.
+5. Other nodes import the block and remove included or invalidated
+   transactions from their local view.
+
+This is why RPC health and P2P health both matter. A public RPC endpoint can
+accept traffic while the node has poor peer propagation, and a well-connected
+private node may intentionally expose no public RPC service at all.
+
+### A validator uses sentry nodes
+
+1. Public peers connect to one or more sentry nodes.
+2. The validator keeps reserved connections to its sentries.
+3. Firewall rules restrict direct public access to the validator machine.
+4. The sentries relay the network data the validator needs for its role.
+5. Operators monitor both the sentries and the validator, because either layer
+   can break the path.
+
+The sentry pattern protects the validator's exposure, but it does not remove
+the need for version alignment, peer monitoring, and incident runbooks.
+
 ## Validators, collators, and parachain data
 
 Polkadot's networking layer becomes more specialized for validators and

--- a/track-3/polkadot-networking-protocol/README.md
+++ b/track-3/polkadot-networking-protocol/README.md
@@ -1,0 +1,259 @@
+# Understanding Polkadot's Networking Protocol
+
+Polkadot is not a single server that applications call. It is a peer-to-peer
+network of nodes that discover each other, exchange blocks and transactions,
+propagate consensus messages, and keep relay-chain and parachain data moving.
+The networking layer is the connective tissue that lets validators, collators,
+full nodes, RPC nodes, and bootnodes participate in the same decentralized
+system.
+
+This article explains the networking protocol at a practical level: what nodes
+need from the network, how peers find and identify each other, what kinds of
+messages flow through the network, and what node operators should monitor.
+
+## Why Polkadot needs a networking protocol
+
+Every blockchain needs a way to move information between independent machines.
+For Polkadot, that problem is broader than "broadcast blocks" because the
+network coordinates both relay-chain consensus and parachain availability.
+
+The networking layer helps with:
+
+- Peer discovery, so a node can join the network without a central directory.
+- Block propagation, so nodes learn about new relay-chain blocks.
+- Transaction propagation, so signed extrinsics can reach block producers.
+- State and block synchronization, so new or lagging nodes can catch up.
+- Validator and collator communication, so parachain candidates, availability
+  data, statements, and approval-related messages can reach the right peers.
+- Operational connectivity, so operators can use bootnodes, reserved nodes,
+  telemetry, and metrics to keep infrastructure healthy.
+
+Networking is therefore not an optional add-on. A node with poor connectivity
+can fall behind, fail to propagate transactions, miss validator duties, or
+create a weak user experience for wallets and applications relying on it.
+
+## libp2p as the foundation
+
+Polkadot's host networking is built on open peer-to-peer protocols, including
+libp2p. libp2p provides a modular stack for peer identity, transport,
+connection encryption, stream multiplexing, protocol negotiation, and peer
+discovery.
+
+At a high level, each node has a peer identity. Other nodes do not need to
+trust a DNS name or a centralized registry to recognize that peer; the peer ID
+is derived from the node's networking key. A running node can then advertise
+addresses and negotiate protocols with other peers.
+
+libp2p matters because Polkadot needs more than one message type. Once two
+nodes are connected, multiplexing lets them open different substreams for
+different application-level protocols. This means block sync, transaction
+propagation, consensus messages, and other protocol-specific traffic can share
+the same underlying peer connection without being treated as one undifferentiated
+byte stream.
+
+## Peer discovery and bootnodes
+
+When a node first starts, it needs at least one way to find peers. Bootnodes
+solve that initial discovery problem. A bootnode is a known, reachable node
+whose address can be placed in configuration or chain specifications. After
+connecting to a bootnode, a node can learn about additional peers and expand
+its view of the network.
+
+Bootnodes are not special consensus authorities. Their job is to help other
+nodes enter the peer graph. A healthy production setup should not depend on a
+single bootnode forever. Once connected, nodes should maintain enough peers to
+continue syncing and propagating data even if one endpoint disappears.
+
+Operators can also use reserved nodes. A reserved node configuration tells a
+node to maintain specific peer connections. This is useful for private
+validator infrastructure, sentry-node layouts, controlled test networks, or
+cases where an operator wants predictable connectivity between machines.
+
+## Node identity and network keys
+
+A Polkadot node has a networking identity separate from its staking or
+validator session keys. The node key is used by libp2p to derive the peer ID.
+Keeping that identity stable is useful for bootnodes and reserved peer setups
+because other nodes can reliably refer to the same peer.
+
+This distinction matters for security reviews:
+
+- A node key identifies a networking peer.
+- Validator keys authorize consensus roles and validator duties.
+- RPC credentials or firewall rules control administrative access.
+
+Do not treat these as the same secret. Exposing a networking key is not the
+same as exposing a validator session key, but it can still damage operational
+trust because peers may rely on that identity for reserved connectivity.
+
+## What full nodes exchange
+
+A normal full node participates in several network flows.
+
+First, it syncs blocks. A new node starts from genesis or from a trusted state
+path and requests blocks, headers, and supporting data until it reaches the
+current best chain. If it falls behind, the same sync logic helps it catch up.
+
+Second, it listens for newly imported blocks from peers. Block propagation is
+what keeps independent nodes aligned around the latest relay-chain history.
+Consensus decides which blocks are valid and finalized; networking spreads the
+data needed for nodes to evaluate and import them.
+
+Third, it handles transactions. When a client submits an extrinsic through RPC,
+the node validates the transaction format and places it into its local
+transaction pool. Valid transactions can then be broadcast across the peer-to-
+peer network so block producers can include them.
+
+Fourth, it serves data to other peers. A well-connected full node is not only a
+consumer of network data. It can also help other peers sync and stay healthy.
+
+## Validators, collators, and parachain data
+
+Polkadot's networking layer becomes more specialized for validators and
+collators.
+
+Validators participate in relay-chain consensus and parachain validation. They
+need access to the messages and data required to evaluate parachain candidates,
+distribute availability information, and participate in approval-related
+protocols. The exact protocols are more involved than ordinary block gossip,
+but the core requirement is simple: validator nodes need reliable, timely, and
+secure peer communication.
+
+Collators maintain parachain nodes and produce parachain block candidates for
+validators to check. Their connectivity matters for parachain liveness because
+a collator that cannot communicate candidate data effectively can slow down or
+disrupt the parachain it serves.
+
+This is why production operators often pay close attention to:
+
+- Peer count and peer quality.
+- Network latency and packet loss.
+- Whether validator nodes are reachable through a sentry-node design.
+- Whether collators can maintain stable relay-chain and parachain connectivity.
+- Whether node versions are compatible with the current runtime and networking
+  expectations.
+
+## RPC is not the same as P2P
+
+It is easy to confuse two different interfaces:
+
+- P2P networking connects the node to other blockchain nodes.
+- RPC exposes an API for wallets, dashboards, scripts, indexers, and
+  applications.
+
+A node can have healthy P2P connectivity while exposing no public RPC endpoint.
+That is common for validators, where the operator may want to minimize the
+public attack surface. Conversely, a public RPC node may be useful for
+applications but should be protected, monitored, and rate-limited because it
+receives user-facing traffic.
+
+The default security posture should be conservative:
+
+- Keep administrative RPC off the public internet.
+- Expose only the RPC methods and origins that are actually needed.
+- Put public RPC behind appropriate infrastructure.
+- Do not use a validator node as a casual public RPC endpoint.
+
+## Sentry nodes and validator protection
+
+Many validator operators use sentry nodes. A sentry node is a publicly
+reachable node that sits between the broader network and a validator. The
+validator connects to its sentries, and the sentries connect to the wider P2P
+network.
+
+The goal is to reduce direct exposure of the validator machine. The validator
+still receives the network data it needs, but public peers do not need to
+connect directly to the validator. This pattern helps with denial-of-service
+resilience, firewalling, network isolation, and operational control.
+
+The tradeoff is complexity. A sentry setup requires careful configuration:
+reserved peers, firewall rules, monitoring, version management, and clear
+runbooks for replacing nodes during incidents.
+
+## Telemetry, metrics, and troubleshooting
+
+Networking problems often look like application or consensus problems at first.
+A node that is behind, missing peers, or repeatedly disconnecting may fail to
+serve RPC users, miss validator duties, or show poor indexing behavior.
+
+Useful signals include:
+
+- Peer count and peer churn.
+- Sync status and best block height.
+- Finalized block height.
+- Import queue behavior.
+- Transaction pool size.
+- Network bandwidth and error logs.
+- Prometheus metrics, if enabled.
+- Optional telemetry visibility, where configured.
+
+Troubleshooting usually starts with simple questions:
+
+1. Is the node on the expected chain specification?
+2. Is the node listening on the intended P2P address and port?
+3. Can it reach bootnodes or reserved peers?
+4. Is the firewall blocking inbound or outbound P2P traffic?
+5. Is the node version compatible with the network?
+6. Is disk, CPU, or memory pressure causing slow imports?
+
+Many "network" incidents are partly infrastructure incidents. Slow disks,
+misconfigured firewalls, exhausted file descriptors, overloaded RPC endpoints,
+or stale binaries can all show up as poor peer behavior.
+
+## Common misconceptions
+
+### "A bootnode controls the network"
+
+Bootnodes help with discovery. They do not decide consensus and should not be
+treated as centralized authorities.
+
+### "More peers always means better performance"
+
+More peers can help up to a point, but peer quality, latency, and stability
+matter. Too many connections can add overhead without improving reliability.
+
+### "RPC connectivity proves P2P health"
+
+RPC and P2P are different interfaces. A node can answer local RPC while being
+poorly connected to peers, or it can be well connected to peers while exposing
+no public RPC.
+
+### "Validator keys and node keys are the same"
+
+They are different. Validator/session keys are consensus-sensitive. Node keys
+identify the networking peer.
+
+## Operator checklist
+
+Before relying on a node in production, confirm:
+
+- The node is using the correct chain specification.
+- P2P listening addresses are configured intentionally.
+- Bootnodes or reserved nodes are reachable.
+- The node key is stable where peer identity matters.
+- Public RPC exposure is minimized and protected.
+- Metrics and logs are collected.
+- The node can keep up with best and finalized blocks.
+- Disk and network performance are adequate.
+- Upgrade and rollback procedures are documented.
+
+## Summary
+
+Polkadot's networking protocol is the system that lets independent nodes act
+like one decentralized network. libp2p gives nodes peer identity, discovery,
+multiplexed connections, and protocol negotiation. Polkadot then uses those
+connections to move blocks, transactions, sync data, consensus messages, and
+parachain-related data between the right participants.
+
+For developers, the key lesson is that networking is part of the protocol's
+correctness story, not just infrastructure plumbing. For operators, the key
+lesson is that stable peer connectivity, careful RPC exposure, metrics, and
+clear node roles are essential to running reliable Polkadot infrastructure.
+
+## References
+
+- [Polkadot Developer Docs: Node Infrastructure Overview](https://docs.polkadot.com/node-infrastructure/)
+- [Polkadot Developer Docs: Set Up a Bootnode](https://docs.polkadot.com/node-infrastructure/run-a-node/relay-chain/bootnode/)
+- [Polkadot Developer Docs: Set Up a Node](https://docs.polkadot.com/infrastructure/running-a-node/setup-full-node)
+- [libp2p Documentation](https://docs.libp2p.io/)
+- [Substrate Docs: Networks and Nodes](https://docs.substrate.io/learn/networks-and-nodes/)

--- a/track-3/polkadot-networking-protocol/review-checklist.md
+++ b/track-3/polkadot-networking-protocol/review-checklist.md
@@ -17,6 +17,8 @@ publishing or accepting it as a Track 3 technical blog submission.
 
 - Peer discovery, bootnodes, node identity, block sync, transaction
   propagation, and validator or collator communication are covered.
+- The article includes concrete message-flow examples for node sync, submitted
+  transaction propagation, and sentry-protected validator connectivity.
 - The article explains why parachain data makes Polkadot networking broader
   than simple block gossip.
 - Operational patterns such as sentry nodes, reserved peers, metrics, and
@@ -26,6 +28,8 @@ publishing or accepting it as a Track 3 technical blog submission.
 ## Builder usefulness
 
 - The article gives readers a practical mental model for how nodes communicate.
+- The message-flow examples connect abstract networking roles to operator
+  checks.
 - The operator checklist is concrete enough to support a production-readiness
   review.
 - Troubleshooting guidance distinguishes network, RPC, and infrastructure

--- a/track-3/polkadot-networking-protocol/review-checklist.md
+++ b/track-3/polkadot-networking-protocol/review-checklist.md
@@ -1,0 +1,41 @@
+# Review Checklist
+
+Use this checklist to review the Polkadot networking protocol article before
+publishing or accepting it as a Track 3 technical blog submission.
+
+## Source accuracy
+
+- The article explains Polkadot networking as peer-to-peer infrastructure, not
+  a centralized server model.
+- The article correctly separates P2P networking from JSON-RPC access.
+- The article separates node keys from validator or session keys.
+- The article avoids hardcoded peer counts, port assumptions, or validator
+  counts that can drift.
+- The references include official Polkadot and libp2p documentation.
+
+## Technical completeness
+
+- Peer discovery, bootnodes, node identity, block sync, transaction
+  propagation, and validator or collator communication are covered.
+- The article explains why parachain data makes Polkadot networking broader
+  than simple block gossip.
+- Operational patterns such as sentry nodes, reserved peers, metrics, and
+  telemetry are mentioned.
+- The security discussion includes RPC exposure and validator protection.
+
+## Builder usefulness
+
+- The article gives readers a practical mental model for how nodes communicate.
+- The operator checklist is concrete enough to support a production-readiness
+  review.
+- Troubleshooting guidance distinguishes network, RPC, and infrastructure
+  failure modes.
+- The article avoids implying that higher peer count alone proves better
+  health.
+
+## Editorial quality
+
+- Headings are clear and scannable.
+- Markdown formatting is consistent.
+- The article does not use unsupported price, investment, or market claims.
+- The tone is technical and neutral.


### PR DESCRIPTION
Summary
- add a Track 3 technical blog explaining Polkadot networking at a practical operator/developer level
- cover peer discovery, bootnodes, node identity, block and transaction propagation, validator/collator communication, RPC separation, sentry nodes, and troubleshooting signals
- add a focused review checklist for source accuracy, technical completeness, builder usefulness, and editorial quality

Closes #26

Validation
- npx --yes markdownlint-cli@0.43.0 track-3/polkadot-networking-protocol/*.md
- git diff --cached --check
- LC_ALL=C rg -n '[^\\x00-\\x7F]' track-3/polkadot-networking-protocol\n- checked all README reference links with curl; all returned HTTP 200\n\nBounty payout\n- Payout details can be provided from zaixincheng174-ai on acceptance.